### PR TITLE
Switch over to using OSRng for random numbers.

### DIFF
--- a/src/rust_crypto/pbkdf2.rs
+++ b/src/rust_crypto/pbkdf2.rs
@@ -9,7 +9,7 @@
  * http://tools.ietf.org/html/rfc2898.
  */
 
-use std::rand::{IsaacRng, Rng};
+use std::rand::{OSRng, Rng};
 use std::vec;
 use std::vec::MutableCloneableVector;
 
@@ -131,7 +131,7 @@ pub fn pbkdf2<M: Mac>(mac: &mut M, salt: &[u8], c: u32, output: &mut [u8]) {
  *
  */
 pub fn pbkdf2_simple(password: &str, c: u32) -> ~str {
-    let mut rng = IsaacRng::new();
+    let mut rng = OSRng::new();
 
     // 128-bit salt
     let salt: ~[u8] = rng.gen_vec(16);

--- a/src/rust_crypto/scrypt.rs
+++ b/src/rust_crypto/scrypt.rs
@@ -13,7 +13,7 @@
  */
 
 use std::num::ToPrimitive;
-use std::rand::{IsaacRng, Rng};
+use std::rand::{OSRng, Rng};
 use std::sys::size_of;
 use std::vec;
 use std::vec::MutableCloneableVector;
@@ -275,7 +275,7 @@ pub fn scrypt(password: &[u8], salt: &[u8], params: &ScryptParams, output: &mut 
  *
  */
 pub fn scrypt_simple(password: &str, params: &ScryptParams) -> ~str {
-    let mut rng = IsaacRng::new();
+    let mut rng = OSRng::new();
 
     // 128-bit salt
     let salt: ~[u8] = rng.gen_vec(16);


### PR DESCRIPTION
Switch over to using OSRng for generating random numbers. IsaacRng is seeded by a strong OS random source, so, it can't be any stronger than that source - it can only be weaker. So, we might as well just use the OS random source directly.
