### PR TITLE
Change where size_of() is imported from since it has been moved in the standard library

### DIFF
--- a/src/rust_crypto/scrypt.rs
+++ b/src/rust_crypto/scrypt.rs
@@ -14,7 +14,7 @@
 
 use std::num::ToPrimitive;
 use std::rand::{OSRng, Rng};
-use std::sys::size_of;
+use std::mem::size_of;
 use std::vec;
 use std::vec::MutableCloneableVector;
 


### PR DESCRIPTION
Change where size_of() is imported from since it has been moved in the standard library
