### PR TITLE
Enable asm feature.

### DIFF
--- a/src/rust_crypto/lib.rs
+++ b/src/rust_crypto/lib.rs
@@ -10,6 +10,7 @@
        url = "https://github.com/DaGenix/rust-crypto/src/rust-crypto")];
 #[license = "MIT/ASL2"];
 
+#[feature(asm)];
 #[feature(macro_rules)];
 
 extern mod extra;

--- a/src/rust_crypto/test.rs
+++ b/src/rust_crypto/test.rs
@@ -4,6 +4,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[feature(asm)];
 #[feature(macro_rules)];
 
 extern mod extra;


### PR DESCRIPTION
Enable asm feature. I suspect this flag will soon be required to use inline assembly, so might as well enable it now to prevent the build from breaking.
