### PR TITLE
Replaced ~[] use with Vec<> and removed warning suppression.

### DIFF
--- a/src/rust-crypto/lib.rs
+++ b/src/rust-crypto/lib.rs
@@ -11,8 +11,6 @@
 #![feature(macro_rules)]
 #![feature(simd)]
 
-#![allow(deprecated_owned_vector)]
-
 extern crate rand;
 extern crate serialize;
 

--- a/src/rust-crypto/pbkdf2.rs
+++ b/src/rust-crypto/pbkdf2.rs
@@ -136,21 +136,21 @@ pub fn pbkdf2_simple(password: &str, c: u32) -> IoResult<~str> {
     let mut rng = try!(OSRng::new());
 
     // 128-bit salt
-    let salt: ~[u8] = rng.gen_vec(16);
+    let salt: Vec<u8> = rng.gen_vec(16);
 
     // 256-bit derived key
     let mut dk = [0u8, ..32];
 
     let mut mac = Hmac::new(Sha256::new(), password.as_bytes());
 
-    pbkdf2(&mut mac, salt, c, dk);
+    pbkdf2(&mut mac, salt.as_slice(), c, dk);
 
     let mut result = ~"$rpbkdf2$0$";
     let mut tmp = [0u8, ..4];
     write_u32_be(tmp, c);
     result.push_str(tmp.to_base64(base64::STANDARD));
     result.push_char('$');
-    result.push_str(salt.to_base64(base64::STANDARD));
+    result.push_str(salt.as_slice().to_base64(base64::STANDARD));
     result.push_char('$');
     result.push_str(dk.to_base64(base64::STANDARD));
     result.push_char('$');

--- a/src/rust-crypto/scrypt.rs
+++ b/src/rust-crypto/scrypt.rs
@@ -279,12 +279,12 @@ pub fn scrypt_simple(password: &str, params: &ScryptParams) -> IoResult<~str> {
     let mut rng = try!(OSRng::new());
 
     // 128-bit salt
-    let salt: ~[u8] = rng.gen_vec(16);
+    let salt: Vec<u8> = rng.gen_vec(16);
 
     // 256-bit derived key
     let mut dk = [0u8, ..32];
 
-    scrypt(password.as_bytes(), salt, params, dk);
+    scrypt(password.as_bytes(), salt.as_slice(), params, dk);
 
     let mut result = ~"$rscrypt$";
     if params.r < 256 && params.p < 256 {
@@ -303,7 +303,7 @@ pub fn scrypt_simple(password: &str, params: &ScryptParams) -> IoResult<~str> {
         result.push_str(tmp.to_base64(base64::STANDARD));
     }
     result.push_char('$');
-    result.push_str(salt.to_base64(base64::STANDARD));
+    result.push_str(salt.as_slice().to_base64(base64::STANDARD));
     result.push_char('$');
     result.push_str(dk.to_base64(base64::STANDARD));
     result.push_char('$');


### PR DESCRIPTION
Tests pass, builds with current Rust master.
