### PR TITLE
Replaced ~str with StrBuf where necessary

### DIFF
--- a/src/rust-crypto/digest.rs
+++ b/src/rust-crypto/digest.rs
@@ -80,7 +80,7 @@ pub trait Digest {
 }
 
 fn to_hex(rr: &[u8]) -> ~str {
-    let mut s = ~"";
+    let mut s = StrBuf::new();
     for b in rr.iter() {
         let hex = (*b as uint).to_str_radix(16u);
         if hex.len() == 1 {
@@ -88,5 +88,5 @@ fn to_hex(rr: &[u8]) -> ~str {
         }
         s.push_str(hex);
     }
-    return s;
+    return s.into_owned();
 }

--- a/src/rust-crypto/pbkdf2.rs
+++ b/src/rust-crypto/pbkdf2.rs
@@ -145,7 +145,7 @@ pub fn pbkdf2_simple(password: &str, c: u32) -> IoResult<~str> {
 
     pbkdf2(&mut mac, salt.as_slice(), c, dk);
 
-    let mut result = ~"$rpbkdf2$0$";
+    let mut result = StrBuf::from_owned_str(~"$rpbkdf2$0$");
     let mut tmp = [0u8, ..4];
     write_u32_be(tmp, c);
     result.push_str(tmp.to_base64(base64::STANDARD));
@@ -155,7 +155,7 @@ pub fn pbkdf2_simple(password: &str, c: u32) -> IoResult<~str> {
     result.push_str(dk.to_base64(base64::STANDARD));
     result.push_char('$');
 
-    return Ok(result);
+    return Ok(result.into_owned());
 }
 
 /**

--- a/src/rust-crypto/scrypt.rs
+++ b/src/rust-crypto/scrypt.rs
@@ -286,7 +286,7 @@ pub fn scrypt_simple(password: &str, params: &ScryptParams) -> IoResult<~str> {
 
     scrypt(password.as_bytes(), salt.as_slice(), params, dk);
 
-    let mut result = ~"$rscrypt$";
+    let mut result = StrBuf::from_owned_str(~"$rscrypt$");
     if params.r < 256 && params.p < 256 {
         result.push_str("0$");
         let mut tmp = [0u8, ..3];
@@ -308,7 +308,7 @@ pub fn scrypt_simple(password: &str, params: &ScryptParams) -> IoResult<~str> {
     result.push_str(dk.to_base64(base64::STANDARD));
     result.push_char('$');
 
-    return Ok(result);
+    return Ok(result.into_owned());
 }
 
 /**


### PR DESCRIPTION
Avoided changing API for now, so used .into_owned() to convert back to ~str for return.

"make check" fails (and was not run), but was failing before these changes.
