### PR TITLE
Speed up the read_{u32,u64}{,v}_{le,be} and write_{u32,u64}_{be,le} functions

### DIFF
--- a/src/rust-crypto/cryptoutil.rs
+++ b/src/rust-crypto/cryptoutil.rs
@@ -9,7 +9,9 @@
 // except according to those terms.
 
 use std;
+use std::mem;
 use std::num::{One, Zero, Int, CheckedAdd};
+use std::ptr;
 use std::slice::bytes::{MutableByteVector, copy_memory};
 
 use buffer::{ReadBuffer, WriteBuffer, BufferResult, BufferUnderflow, BufferOverflow};
@@ -17,91 +19,103 @@ use symmetriccipher::{SynchronousStreamCipher, SymmetricCipherError};
 
 /// Write a u64 into a vector, which must be 8 bytes long. The value is written in big-endian
 /// format.
-pub fn write_u64_be(dst: &mut[u8], input: u64) {
-    dst[0] = ((input & 0xff00000000000000) >> 56) as u8;
-    dst[1] = ((input & 0x00ff000000000000) >> 48) as u8;
-    dst[2] = ((input & 0x0000ff0000000000) >> 40) as u8;
-    dst[3] = ((input & 0x000000ff00000000) >> 32) as u8;
-    dst[4] = ((input & 0x00000000ff000000) >> 24) as u8;
-    dst[5] = ((input & 0x0000000000ff0000) >> 16) as u8;
-    dst[6] = ((input & 0x000000000000ff00) >> 8) as u8;
-    dst[7] = (input & 0x00000000000000ff) as u8;
+pub fn write_u64_be(dst: &mut[u8], mut input: u64) {
+    assert!(dst.len() == 8);
+    input = input.to_be();
+    unsafe {
+        let tmp = &input as *const _ as *const u8;
+        ptr::copy_nonoverlapping_memory(dst.unsafe_mut_ref(0), tmp, 8);
+    }
 }
 
 /// Write a u32 into a vector, which must be 4 bytes long. The value is written in big-endian
 /// format.
-pub fn write_u32_be(dst: &mut[u8], input: u32) {
-    dst[0] = ((input & 0xff000000) >> 24) as u8;
-    dst[1] = ((input & 0x00ff0000) >> 16) as u8;
-    dst[2] = ((input & 0x0000ff00) >> 8) as u8;
-    dst[3] = (input & 0x000000ff) as u8;
+pub fn write_u32_be(dst: &mut [u8], mut input: u32) {
+    assert!(dst.len() == 4);
+    input = input.to_be();
+    unsafe {
+        let tmp = &input as *const _ as *const u8;
+        ptr::copy_nonoverlapping_memory(dst.unsafe_mut_ref(0), tmp, 4);
+    }
 }
 
 /// Write a u32 into a vector, which must be 4 bytes long. The value is written in little-endian
 /// format.
-pub fn write_u32_le(dst: &mut[u8], input: u32) {
-    dst[3] = ((input & 0xff000000) >> 24) as u8;
-    dst[2] = ((input & 0x00ff0000) >> 16) as u8;
-    dst[1] = ((input & 0x0000ff00) >> 8) as u8;
-    dst[0] = (input & 0x000000ff) as u8;
+pub fn write_u32_le(dst: &mut[u8], mut input: u32) {
+    assert!(dst.len() == 4);
+    input = input.to_le();
+    unsafe {
+        let tmp = &input as *const _ as *const u8;
+        ptr::copy_nonoverlapping_memory(dst.unsafe_mut_ref(0), tmp, 4);
+    }
 }
 
 /// Read a vector of bytes into a vector of u64s. The values are read in big-endian format.
 pub fn read_u64v_be(dst: &mut[u64], input: &[u8]) {
-    let mut pos = 0u;
-    for chunk in input.chunks(8) {
-        dst[pos] = read_u64_be(chunk);
-        pos += 1;
+    assert!(dst.len() * 8 == input.len());
+    unsafe {
+        let mut x = dst.unsafe_mut_ref(0) as *mut u64;
+        let mut y = input.unsafe_ref(0) as *const u8;
+        for _ in range(0, dst.len()) {
+            let mut tmp: u64 = mem::uninitialized();
+            ptr::copy_nonoverlapping_memory(&mut tmp as *mut _ as *mut u8, y, 8);
+            *x = Int::from_be(tmp);
+            x = x.offset(1);
+            y = y.offset(8);
+        }
     }
 }
 
 /// Read a vector of bytes into a vector of u32s. The values are read in big-endian format.
 pub fn read_u32v_be(dst: &mut[u32], input: &[u8]) {
-    let mut pos = 0u;
-    for chunk in input.chunks(4) {
-        dst[pos] = read_u32_be(chunk);
-        pos += 1;
+    assert!(dst.len() * 4 == input.len());
+    unsafe {
+        let mut x = dst.unsafe_mut_ref(0) as *mut u32;
+        let mut y = input.unsafe_ref(0) as *const u8;
+        for _ in range(0, dst.len()) {
+            let mut tmp: u32 = mem::uninitialized();
+            ptr::copy_nonoverlapping_memory(&mut tmp as *mut _ as *mut u8, y, 4);
+            *x = Int::from_be(tmp);
+            x = x.offset(1);
+            y = y.offset(4);
+        }
     }
 }
 
 /// Read a vector of bytes into a vector of u32s. The values are read in little-endian format.
 pub fn read_u32v_le(dst: &mut[u32], input: &[u8]) {
-    let mut pos = 0u;
-    for chunk in input.chunks(4) {
-        dst[pos] = read_u32_le(chunk);
-        pos += 1;
+    assert!(dst.len() * 4 == input.len());
+    unsafe {
+        let mut x = dst.unsafe_mut_ref(0) as *mut u32;
+        let mut y = input.unsafe_ref(0) as *const u8;
+        for _ in range(0, dst.len()) {
+            let mut tmp: u32 = mem::uninitialized();
+            ptr::copy_nonoverlapping_memory(&mut tmp as *mut _ as *mut u8, y, 4);
+            *x = Int::from_le(tmp);
+            x = x.offset(1);
+            y = y.offset(4);
+        }
     }
-}
-
-/// Read the value of a vector of bytes as a u64 value in big-endian format.
-pub fn read_u64_be(input: &[u8]) -> u64 {
-    return
-        (input[0] as u64) << 56 |
-        (input[1] as u64) << 48 |
-        (input[2] as u64) << 40 |
-        (input[3] as u64) << 32 |
-        (input[4] as u64) << 24 |
-        (input[5] as u64) << 16 |
-        (input[6] as u64) << 8 |
-        (input[7] as u64);
 }
 
 /// Read the value of a vector of bytes as a u32 value in little-endian format.
 pub fn read_u32_le(input: &[u8]) -> u32 {
-    return
-        (input[3] as u32) << 24 |
-        (input[2] as u32) << 16 |
-        (input[1] as u32) << 8 |
-        (input[0] as u32);
+    assert!(input.len() == 4);
+    unsafe {
+        let mut tmp: u32 = mem::uninitialized();
+        ptr::copy_nonoverlapping_memory(&mut tmp as *mut _ as *mut u8, input.unsafe_ref(0), 4);
+        return Int::from_le(tmp);
+    }
 }
 
 /// Read the value of a vector of bytes as a u32 value in big-endian format.
 pub fn read_u32_be(input: &[u8]) -> u32 {
-    return
-        (input[0] as u32) << 24 |
-        (input[1] as u32) << 16 |
-        (input[2] as u32) << 8 |
-        (input[3] as u32);
+    assert!(input.len() == 4);
+    unsafe {
+        let mut tmp: u32 = mem::uninitialized();
+        ptr::copy_nonoverlapping_memory(&mut tmp as *mut _ as *mut u8, input.unsafe_ref(0), 4);
+        return Int::from_be(tmp);
+    }
 }
 
 


### PR DESCRIPTION
The original implementations of these functions were fairly efficient, however
they didn't respect the alignment requirements of the platform which could
cause crashes on ARM. The previous implementations of these functions were
designed to avoid the alignment issues, not necessarily to be optimal. The
result is that while the functions worked on ARM, they did a lot of unecessary
bounds checks and were not using the byte-swap instrinsics. I confirmed that
LLVM was not able to eliminate these checks by examining the X86_64 assembly
that was generated.

The functions have been re-written to use a similiar strategy as the original
implementations - namely processing u32 or u64 chunks of memory all at once
and using the byte-swap instrinsics. In order to avoid the alignment issues
of the original impementation, instead of coercing [u8] arrays into
[u64](or [u32]) arrays (which might not be properly aligned) and then reading
or writing them, the new imlementation only works on [u8] arrays using the
copy_nonoverlapping_memory() instrinsic which does not have any particular
alignment restrictions.

The new implementations may be a bit slower than the original ones - it looks
like the original ones would generate some slightly different code using
some of the SSE registers. However, they definitally generate smaller code
with many fewer branches than the previous ones.
