### PR TITLE
removed slice::MutableClonableSlice reference from pbkdf2

### DIFF
--- a/src/rust-crypto/pbkdf2.rs
+++ b/src/rust-crypto/pbkdf2.rs
@@ -11,7 +11,6 @@
 
 use std::io::IoResult;
 use std::rand::{OsRng, Rng};
-use std::slice::MutableCloneableSlice;
 
 use serialize::base64;
 use serialize::base64::{FromBase64, ToBase64};


### PR DESCRIPTION
Removed use std::slice::MutableCloneableSlice; from pbkdf2.rs  Wasnt being used and not compatible with recent changes to std.
