### PR TITLE
Update Cargo script ([[lib]] becomes [lib]) -> but cargo script still doesn't work

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "rust-crypto"
 version = "0.1.0"
 authors = []
 
-[[lib]]
+[lib]
 name = "rust-crypto"
 path = "src/rust-crypto/lib.rs"
 

--- a/src/rust-crypto/blockmodes.rs
+++ b/src/rust-crypto/blockmodes.rs
@@ -1143,9 +1143,10 @@ mod test {
         use std::rand;
         use std::rand::Rng;
 
-        let mut rng1: rand::StdRng = rand::SeedableRng::from_seed(&[1, 2, 3, 4]);
-        let mut rng2: rand::StdRng = rand::SeedableRng::from_seed(&[1, 2, 3, 4]);
-        let mut rng3: rand::StdRng = rand::SeedableRng::from_seed(&[1, 2, 3, 4]);
+        let tmp : &[_] = &[1, 2, 3, 4];
+        let mut rng1: rand::StdRng = rand::SeedableRng::from_seed(tmp);
+        let mut rng2: rand::StdRng = rand::SeedableRng::from_seed(tmp);
+        let mut rng3: rand::StdRng = rand::SeedableRng::from_seed(tmp);
         let max_size = cmp::max(test.get_plain().len(), test.get_cipher().len());
 
         let r1 = || {

--- a/src/rust-crypto/util.rs
+++ b/src/rust-crypto/util.rs
@@ -31,6 +31,7 @@ pub fn supports_aesni() -> bool {
 #[cfg(target_arch = "x86")]
 #[cfg(target_arch = "x86_64")]
 #[allow(dead_assignment)]
+#[allow(unused_variable)]
 unsafe fn fixed_time_eq_asm(mut lhsp: *const u8, mut rhsp: *const u8, mut count: uint) -> bool {
     let mut result: u8 = 0;
 


### PR DESCRIPTION
Remove errors
Remove warnings

Some of the code is not really rust-like, for example :

``` Rust
return result == 0;
// Should be :
result == 0
```
