### PR TITLE
Update for Rust syntax changes

### DIFF
--- a/src/rust-crypto-util/tool.rs
+++ b/src/rust-crypto-util/tool.rs
@@ -8,7 +8,7 @@
 #![crate_name = "rust-crypto-util"]
 
 extern crate getopts;
-extern crate rust_crypto = "rust-crypto";
+extern crate "rust-crypto" as rust_crypto;
 
 use std::io;
 use std::os;


### PR DESCRIPTION
extern crate foo = "bar";
is now
extern crate "bar" as foo;
as per Rust RFC 47.
