### PR TITLE
final is now a reserved word, this changes instances of final to finalize(d)

### DIFF
--- a/src/rust-crypto/blake2b.rs
+++ b/src/rust-crypto/blake2b.rs
@@ -271,7 +271,7 @@ impl Blake2b {
         }
     }
 
-    fn final( &mut self, out: &mut [u8] ) {
+    fn finalize( &mut self, out: &mut [u8] ) {
         assert!(out.len() == self.digest_length as uint);
         if !self.computed {
             if self.buflen > BLAKE2B_BLOCKBYTES {
@@ -305,7 +305,7 @@ impl Blake2b {
         let mut hasher : Blake2b = if key.len() > 0 { Blake2b::new_keyed(out.len(), key) } else { Blake2b::new(out.len()) };
 
         hasher.update(input);
-        hasher.final(out);
+        hasher.finalize(out);
     }
 
 }
@@ -331,7 +331,7 @@ impl Digest for Blake2b {
         self.apply_param(&Blake2b::default_param(len));
     }
     fn input(&mut self, msg: &[u8]) { self.update(msg); }
-    fn result(&mut self, out: &mut [u8]) { self.final(out); }
+    fn result(&mut self, out: &mut [u8]) { self.finalize(out); }
     fn output_bits(&self) -> uint { 8 * (self.digest_length as uint) }
     fn block_size(&self) -> uint { 8 * BLAKE2B_BLOCKBYTES }
 }
@@ -387,7 +387,7 @@ impl Mac for Blake2b {
      * the security provided by a Mac function.
      */
     fn raw_result(&mut self, output: &mut [u8]) {
-        self.final(output);
+        self.finalize(output);
     }
 
     /**


### PR DESCRIPTION
`final` is now a reserved word per [1426f5834c](https://github.com/rust-lang/rust/commit/1426f5834c96234bc1998921e889cfc5ca4893c8) in rust-lang/rust. This changes instances of final to finalize and finalized in two files to allow compilation.
