### PR TITLE
Enable slicing_syntax and disable AES implementations

### DIFF
--- a/src/rust-crypto/lib.rs
+++ b/src/rust-crypto/lib.rs
@@ -16,12 +16,12 @@ extern crate serialize;
 extern crate time;
 #[cfg(test)] extern crate test;
 
-pub mod aes;
-pub mod aessafe;
+//pub mod aes;
+//pub mod aessafe;
 pub mod bcrypt;
 pub mod bcrypt_pbkdf;
 pub mod blake2b;
-pub mod blockmodes;
+//pub mod blockmodes;
 pub mod blowfish;
 pub mod buffer;
 pub mod chacha20;
@@ -43,5 +43,5 @@ pub mod sha2;
 pub mod symmetriccipher;
 pub mod util;
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-pub mod aesni;
+//#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+//pub mod aesni;

--- a/src/rust-crypto/test.rs
+++ b/src/rust-crypto/test.rs
@@ -12,12 +12,12 @@
 extern crate serialize;
 extern crate test;
 
-pub mod aes;
-pub mod aessafe;
+//pub mod aes;
+//pub mod aessafe;
 pub mod bcrypt;
 pub mod bcrypt_pbkdf;
 pub mod blake2b;
-pub mod blockmodes;
+//pub mod blockmodes;
 pub mod blowfish;
 pub mod buffer;
 pub mod chacha20;
@@ -38,6 +38,5 @@ pub mod sha2;
 pub mod symmetriccipher;
 pub mod util;
 
-#[cfg(target_arch = "x86")]
-#[cfg(target_arch = "x86_64")]
-pub mod aesni;
+//#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+//pub mod aesni;


### PR DESCRIPTION
The AesSafe implementation is currently broken due to what appears to be a bug in the version of LLVM that Rust is using. The result is that it compiles but produces incorrect data. Until its fixed, its probably better to make sure that no one is using it.
