### PR TITLE
Disable Fortuna

### DIFF
--- a/src/rust-crypto/lib.rs
+++ b/src/rust-crypto/lib.rs
@@ -27,7 +27,7 @@ pub mod buffer;
 pub mod chacha20;
 mod cryptoutil;
 pub mod digest;
-pub mod fortuna;
+//pub mod fortuna;
 pub mod ghash;
 pub mod hmac;
 pub mod mac;


### PR DESCRIPTION
Temporarily disable Fortuna as it depends on aessafe. Should fix #129.
