### PR TITLE
dead_assignment -> unused_assignments

### DIFF
--- a/src/rust-crypto/aesni.rs
+++ b/src/rust-crypto/aesni.rs
@@ -86,7 +86,7 @@ unsafe fn aesimc(round_keys: *mut u8) {
     )
 }
 
-#[allow(dead_assignment)]
+#[allow(unused_assignments)]
 fn setup_working_key_aesni_128(key: &[u8], key_type: KeyType, round_key: &mut [u8]) {
     unsafe {
         let mut round_keysp: *mut u8 = round_key.unsafe_mut(0);
@@ -154,7 +154,7 @@ fn setup_working_key_aesni_128(key: &[u8], key_type: KeyType, round_key: &mut [u
     }
 }
 
-#[allow(dead_assignment)]
+#[allow(unused_assignments)]
 fn setup_working_key_aesni_192(key: &[u8], key_type: KeyType, round_key: &mut [u8]) {
     unsafe {
         let mut round_keysp: *mut u8 = round_key.unsafe_mut(0);
@@ -257,7 +257,7 @@ fn setup_working_key_aesni_192(key: &[u8], key_type: KeyType, round_key: &mut [u
     }
 }
 
-#[allow(dead_assignment)]
+#[allow(unused_assignments)]
 fn setup_working_key_aesni_256(key: &[u8], key_type: KeyType, round_key: &mut [u8]) {
     unsafe {
         let mut round_keysp: *mut u8 = round_key.unsafe_mut(0);
@@ -368,7 +368,7 @@ fn setup_working_key_aesni_256(key: &[u8], key_type: KeyType, round_key: &mut [u
     }
 }
 
-#[allow(dead_assignment)]
+#[allow(unused_assignments)]
 fn encrypt_block_aseni(rounds: uint, input: &[u8], round_keys: &[u8], output: &mut [u8]) {
     unsafe {
         let mut rounds = rounds;
@@ -410,7 +410,7 @@ fn encrypt_block_aseni(rounds: uint, input: &[u8], round_keys: &[u8], output: &m
     }
 }
 
-#[allow(dead_assignment)]
+#[allow(unused_assignments)]
 fn decrypt_block_aseni(rounds: uint, input: &[u8], round_keys: &[u8], output: &mut [u8]) {
     unsafe {
         let mut rounds = rounds;

--- a/src/rust-crypto/util.rs
+++ b/src/rust-crypto/util.rs
@@ -28,8 +28,8 @@ pub fn supports_aesni() -> bool {
 }
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-#[allow(dead_assignment)]
-#[allow(unused_variable)]
+#[allow(unused_assignments)]
+#[allow(unused_variables)]
 unsafe fn fixed_time_eq_asm(mut lhsp: *const u8, mut rhsp: *const u8, mut count: uint) -> bool {
     let mut result: u8 = 0;
 
@@ -56,7 +56,7 @@ unsafe fn fixed_time_eq_asm(mut lhsp: *const u8, mut rhsp: *const u8, mut count:
 }
 
 #[cfg(target_arch = "arm")]
-#[allow(dead_assignment)]
+#[allow(unused_assignments)]
 unsafe fn fixed_time_eq_asm(mut lhsp: *const u8, mut rhsp: *const u8, mut count: uint) -> bool {
     let mut result: u8 = 0;
 


### PR DESCRIPTION
The warnings dead_assignment and unused_variable were renamed.
