### PR TITLE
Fix problems with comparing fixed sized arrays now that Rust no longer coerces them into slices

### DIFF
--- a/src/rust-crypto/aes.rs
+++ b/src/rust-crypto/aes.rs
@@ -438,9 +438,9 @@ mod test {
         let mut tmp = [0u8, ..16];
         for data in test.data.iter() {
             enc.encrypt_block(data.plain[], tmp);
-            assert!(tmp == data.cipher[]);
+            assert!(tmp[] == data.cipher[]);
             dec.decrypt_block(data.cipher[], tmp);
-            assert!(tmp == data.plain[]);
+            assert!(tmp[] == data.plain[]);
         }
     }
 
@@ -559,9 +559,9 @@ mod test {
         let dec = aessafe::AesSafe128DecryptorX8::new(key);
         let mut tmp = [0u8, ..128];
         enc.encrypt_block_x8(plain, tmp);
-        assert!(tmp == cipher);
+        assert!(tmp[] == cipher[]);
         dec.decrypt_block_x8(cipher, tmp);
-        assert!(tmp == plain);
+        assert!(tmp[] == plain[]);
     }
 
     #[test]
@@ -608,9 +608,9 @@ mod test {
         let dec = aessafe::AesSafe192DecryptorX8::new(key);
         let mut tmp = [0u8, ..128];
         enc.encrypt_block_x8(plain, tmp);
-        assert!(tmp == cipher);
+        assert!(tmp[] == cipher[]);
         dec.decrypt_block_x8(cipher, tmp);
-        assert!(tmp == plain);
+        assert!(tmp[] == plain[]);
     }
 
     #[test]
@@ -659,9 +659,9 @@ mod test {
         let dec = aessafe::AesSafe256DecryptorX8::new(key);
         let mut tmp = [0u8, ..128];
         enc.encrypt_block_x8(plain, tmp);
-        assert!(tmp == cipher);
+        assert!(tmp[] == cipher[]);
         dec.decrypt_block_x8(cipher, tmp);
-        assert!(tmp == plain);
+        assert!(tmp[] == plain[]);
     }
 }
 

--- a/src/rust-crypto/salsa20.rs
+++ b/src/rust-crypto/salsa20.rs
@@ -211,7 +211,7 @@ mod test {
 
         let mut salsa20 = Salsa20::new(key, nonce);
         salsa20.process(input, stream);
-        assert!(stream == result);
+        assert!(stream[] == result[]);
     }
     
     #[test]
@@ -234,7 +234,7 @@ mod test {
 
         let mut salsa20 = Salsa20::new(key, nonce);
         salsa20.process(input, stream);
-        assert!(stream == result);
+        assert!(stream[] == result[]);
     }
 
     #[test]
@@ -272,7 +272,7 @@ mod test {
 
         let mut xsalsa20 = Salsa20::new_xsalsa20(key, nonce);
         xsalsa20.process(input, stream);
-        assert!(stream == result);
+        assert!(stream[] == result[]);
     }
 }
 

--- a/src/rust-crypto/sha1.rs
+++ b/src/rust-crypto/sha1.rs
@@ -250,7 +250,7 @@ mod tests {
         for t in tests.iter() {
             (*sh).input_str(t.input);
             sh.result(out);
-            assert!(t.output[] == out);
+            assert!(t.output[] == out[]);
 
             let out_str = (*sh).result_str();
             assert_eq!(out_str.len(), 40);
@@ -270,7 +270,7 @@ mod tests {
                 left = left - take;
             }
             sh.result(out);
-            assert!(t.output[] == out);
+            assert!(t.output[] == out[]);
 
             let out_str = (*sh).result_str();
             assert_eq!(out_str.len(), 40);


### PR DESCRIPTION
Recent changes to Rust modified how the Eq traits works such that
it no longer coerces fixed sized arrays to slices. This results
in issues if one side of the comparison is a slice and the other
is a fixed sized array or if the arrays have more than 32 elements.
