### PR TITLE
Change MutableCloneableSlice to CloneSlicePrelude

### DIFF
--- a/src/rust-crypto/scrypt.rs
+++ b/src/rust-crypto/scrypt.rs
@@ -16,7 +16,7 @@ use std::io::IoResult;
 use std::num::ToPrimitive;
 use std::mem::size_of;
 use std::rand::{OsRng, Rng};
-use std::slice::MutableCloneableSlice;
+use std::slice::CloneSlicePrelude;
 
 use serialize::base64;
 use serialize::base64::{FromBase64, ToBase64};


### PR DESCRIPTION
Rust nightly 2014-11-06 renamed MutableCloneableSlice to CloneSlicePrelude, among others to new trait names causing rust-crypto to fail. Travis hasn't updated yet, but the latest nightly is already available. This just swaps it out, quick fix.
