### PR TITLE
Use array instead of vec for aesni

### DIFF
--- a/src/rust-crypto/aesni.rs
+++ b/src/rust-crypto/aesni.rs
@@ -4,18 +4,17 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//use std::vec::Vec;
 use aes::{KeySize, KeySize128, KeySize192, KeySize256};
 use symmetriccipher::{BlockEncryptor, BlockDecryptor};
 
 pub struct AesNiEncryptor {
     rounds: uint,
-    round_keys: Vec<u8>
+    round_keys: [u8, ..240]
 }
 
 pub struct AesNiDecryptor {
     rounds: uint,
-    round_keys: Vec<u8>
+    round_keys: [u8, ..240]
 }
 
 impl AesNiEncryptor {
@@ -25,12 +24,11 @@ impl AesNiEncryptor {
             KeySize192 => (12, setup_working_key_aesni_192),
             KeySize256 => (14, setup_working_key_aesni_256)
         };
-        let round_keys = Vec::from_elem(16 * (rounds + 1), 0u8);
         let mut e = AesNiEncryptor {
             rounds: rounds,
-            round_keys: round_keys
+            round_keys: [0u8, ..240]
         };
-        setup_function(key, Encryption, e.round_keys[mut]);
+        setup_function(key, Encryption, e.round_keys.slice_mut(0, size(e.rounds)));
         return e;
     }
 }
@@ -42,27 +40,27 @@ impl AesNiDecryptor {
             KeySize192 => (12, setup_working_key_aesni_192),
             KeySize256 => (14, setup_working_key_aesni_256)
         };
-        let round_keys = Vec::from_elem(16 * (rounds + 1), 0u8);
         let mut d = AesNiDecryptor {
             rounds: rounds,
-            round_keys: round_keys
+            round_keys: [0u8, ..240]
         };
-        setup_function(key, Decryption, d.round_keys[mut]);
+        setup_function(key, Decryption, d.round_keys.slice_mut(0, size(d.rounds)));
         return d;
     }
+
 }
 
 impl BlockEncryptor for AesNiEncryptor {
     fn block_size(&self) -> uint { 16 }
     fn encrypt_block(&self, input: &[u8], output: &mut [u8]) {
-        encrypt_block_aseni(self.rounds, input, self.round_keys[], output);
+        encrypt_block_aseni(self.rounds, input, self.round_keys.slice(0, size(self.rounds))[], output);
     }
 }
 
 impl BlockDecryptor for AesNiDecryptor {
     fn block_size(&self) -> uint { 16 }
     fn decrypt_block(&self, input: &[u8], output: &mut [u8]) {
-        decrypt_block_aseni(self.rounds, input, self.round_keys[], output);
+        decrypt_block_aseni(self.rounds, input, self.round_keys.slice(0, size(self.rounds))[], output);
     }
 }
 
@@ -70,6 +68,9 @@ enum KeyType {
     Encryption,
     Decryption
 }
+
+#[inline(always)]
+fn size(rounds: uint) -> uint { 16 * (rounds + 1) }
 
 #[inline(always)]
 unsafe fn aesimc(round_keys: *mut u8) {


### PR DESCRIPTION
I had a PR previously that used `Vec` for `AesNi...`. This seems better. Thoughts?
