### PR TITLE
Fix new enum scoping rules

### DIFF
--- a/src/rust-crypto/aes.rs
+++ b/src/rust-crypto/aes.rs
@@ -13,6 +13,8 @@ use blockmodes::{PaddingProcessor, EcbEncryptor, EcbDecryptor, CbcEncryptor, Cbc
 use symmetriccipher::{Encryptor, Decryptor, SynchronousStreamCipher};
 use util;
 
+pub use self::KeySize::{KeySize128, KeySize192, KeySize256};
+
 /// AES key size
 pub enum KeySize {
     KeySize128,

--- a/src/rust-crypto/aesni.rs
+++ b/src/rust-crypto/aesni.rs
@@ -8,6 +8,8 @@
 use aes::{KeySize, KeySize128, KeySize192, KeySize256};
 use symmetriccipher::{BlockEncryptor, BlockDecryptor};
 
+use self::KeyType::{Encryption, Decryption};
+
 pub struct AesNiEncryptor {
     rounds: uint,
     round_keys: Vec<u8>

--- a/src/rust-crypto/aessafe.rs
+++ b/src/rust-crypto/aessafe.rs
@@ -130,6 +130,8 @@ use std::iter::range_step;
 use cryptoutil::{read_u32v_le, write_u32_le};
 use symmetriccipher::{BlockEncryptor, BlockEncryptorX8, BlockDecryptor, BlockDecryptorX8};
 
+use self::KeyType::{Encryption, Decryption};
+
 // Using std::unstable::simd::u32x4 results in issues creating static arrays of u32x4 values.
 // Defining the type here avoids that problem. Additionally, we need to implement various trait from
 // libstd which wouldn't be possible if we used that type directly.

--- a/src/rust-crypto/blockmodes.rs
+++ b/src/rust-crypto/blockmodes.rs
@@ -17,6 +17,8 @@ use cryptoutil::symm_enc_or_dec;
 use symmetriccipher::{BlockEncryptor, BlockEncryptorX8, Encryptor, BlockDecryptor, Decryptor,
     SynchronousStreamCipher, SymmetricCipherError, InvalidPadding, InvalidLength};
 
+use self::BlockEngineState::{FastMode, NeedInput, NeedOutput, LastInput, LastInput2, Finished, Error};
+
 /// The BlockProcessor trait is used to implement modes that require processing complete blocks of
 /// data. The methods of this trait are called by the BlockEngine which is in charge of properly
 /// buffering input data.

--- a/src/rust-crypto/buffer.rs
+++ b/src/rust-crypto/buffer.rs
@@ -7,6 +7,8 @@
 use std::cmp;
 use std::slice;
 
+pub use self::BufferResult::{BufferUnderflow, BufferOverflow};
+
 pub enum BufferResult {
     BufferUnderflow,
     BufferOverflow

--- a/src/rust-crypto/symmetriccipher.rs
+++ b/src/rust-crypto/symmetriccipher.rs
@@ -7,6 +7,8 @@
 use buffer::{BufferResult, RefReadBuffer, RefWriteBuffer};
 use cryptoutil::symm_enc_or_dec;
 
+pub use self::SymmetricCipherError::{InvalidLength, InvalidPadding};
+
 pub trait BlockEncryptor {
     fn block_size(&self) -> uint;
     fn encrypt_block(&self, input: &[u8], output: &mut [u8]);


### PR DESCRIPTION
This commit fixes the new rules for scoping enum variants under the namespace of their type.
