### PR TITLE
Rename the crate to just "crypto"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = [ "Crypto", "MD5", "Sha1", "Sha2", "AES" ]
 readme = "README.md"
 
 [lib]
-name = "rust-crypto"
+name = "crypto"
 path = "src/rust-crypto/lib.rs"
 
 [profile.test]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+**NOTE**: The crate name used by rust-crypto has recently changed from `rust-crypto` to
+just `crypto`. Please see the Usage section if you are running into issues due to this
+change.
+
 # Rust-Crypto
 
 [![Build Status](https://travis-ci.org/DaGenix/rust-crypto.png?branch=master)](https://travis-ci.org/DaGenix/rust-crypto)
@@ -21,7 +25,7 @@ rust-crypto = "*"
 and the following to your crate root:
 
 ```rust
-extern crate "rust-crypto" as rust_crypto;
+extern crate crypto;
 ```
 
 ## Contributions

--- a/src/rust-crypto/lib.rs
+++ b/src/rust-crypto/lib.rs
@@ -4,8 +4,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![crate_name = "rust-crypto"]
-
 #![feature(asm)]
 #![feature(macro_rules)]
 #![feature(simd)]


### PR DESCRIPTION
The crate name `rust-crypto` is inconvenient to use since its not a valid Rust identifier. This renames the crate to just `crypto` which is easier to work with.

Closes #153 
