### PR TITLE
Fix breakage on rust nightly

### DIFF
--- a/src/rust-crypto/scrypt.rs
+++ b/src/rust-crypto/scrypt.rs
@@ -16,7 +16,7 @@ use std::io::IoResult;
 use std::num::{Int, ToPrimitive};
 use std::mem::size_of;
 use std::rand::{OsRng, Rng};
-use std::slice::CloneSlicePrelude;
+use std::slice::CloneSliceExt;
 
 use serialize::base64;
 use serialize::base64::{FromBase64, ToBase64};


### PR DESCRIPTION
`std::slice::CloneSlicePrelude` is gone, `clone_from_slice` now lives in the `CloneSliceExt` trait.
