### PR TITLE
add semicolons to item macros

### DIFF
--- a/src/rust-crypto/aesni.rs
+++ b/src/rust-crypto/aesni.rs
@@ -87,7 +87,7 @@ unsafe fn aesimc(round_keys: *mut u8) {
     : "r" (round_keys) // inputs
     : "xmm1", "memory" // clobbers
     : "volatile"
-    )
+    );
 }
 
 #[allow(unused_assignments)]
@@ -144,7 +144,7 @@ fn setup_working_key_aesni_128(key: &[u8], key_type: KeyType, round_key: &mut [u
         : "r" (keyp), "0" (round_keysp)
         : "xmm1", "xmm2", "xmm3", "memory"
         : "volatile"
-        )
+        );
 
         match key_type {
             KeyType::Decryption => {
@@ -247,7 +247,7 @@ fn setup_working_key_aesni_192(key: &[u8], key_type: KeyType, round_key: &mut [u
         : "r" (keyp), "0" (round_keysp)
         : "xmm1", "xmm2", "xmm3", "xmm4", "xmm5", "xmm6", "memory"
         : "volatile"
-        )
+        );
 
         match key_type {
             KeyType::Decryption => {
@@ -358,7 +358,7 @@ fn setup_working_key_aesni_256(key: &[u8], key_type: KeyType, round_key: &mut [u
         : "r" (keyp), "0" (round_keysp)
         : "xmm1", "xmm2", "xmm3", "xmm4", "memory"
         : "volatile"
-        )
+        );
 
         match key_type {
             KeyType::Decryption => {

--- a/src/rust-crypto/aessafe.rs
+++ b/src/rust-crypto/aessafe.rs
@@ -140,8 +140,8 @@ pub struct u32x4(u32, u32, u32, u32);
 
 // There are a variety of places where we need to use u32x4 types with either all bits set or not
 // bits set. These macros make that more succinct.
-macro_rules! o( () => ( u32x4(0, 0, 0, 0) ) )
-macro_rules! x( () => ( u32x4(-1, -1, -1, -1) ) )
+macro_rules! o( () => ( u32x4(0, 0, 0, 0) ) );
+macro_rules! x( () => ( u32x4(-1, -1, -1, -1) ) );
 
 macro_rules! define_aes_struct(
     (
@@ -153,7 +153,7 @@ macro_rules! define_aes_struct(
             sk: [Bs8State<u32>, ..($rounds + 1)]
         }
     )
-)
+);
 
 macro_rules! define_aes_impl(
     (
@@ -176,7 +176,7 @@ macro_rules! define_aes_impl(
             }
         }
     )
-)
+);
 
 macro_rules! define_aes_enc(
     (
@@ -192,7 +192,7 @@ macro_rules! define_aes_enc(
             }
         }
     )
-)
+);
 
 macro_rules! define_aes_dec(
     (
@@ -208,28 +208,28 @@ macro_rules! define_aes_dec(
             }
         }
     )
-)
+);
 
-define_aes_struct!(AesSafe128Encryptor, 10)
-define_aes_struct!(AesSafe128Decryptor, 10)
-define_aes_impl!(AesSafe128Encryptor, Encryption, 10, 16)
-define_aes_impl!(AesSafe128Decryptor, Decryption, 10, 16)
-define_aes_enc!(AesSafe128Encryptor, 10)
-define_aes_dec!(AesSafe128Decryptor, 10)
+define_aes_struct!(AesSafe128Encryptor, 10);
+define_aes_struct!(AesSafe128Decryptor, 10);
+define_aes_impl!(AesSafe128Encryptor, Encryption, 10, 16);
+define_aes_impl!(AesSafe128Decryptor, Decryption, 10, 16);
+define_aes_enc!(AesSafe128Encryptor, 10);
+define_aes_dec!(AesSafe128Decryptor, 10);
 
-define_aes_struct!(AesSafe192Encryptor, 12)
-define_aes_struct!(AesSafe192Decryptor, 12)
-define_aes_impl!(AesSafe192Encryptor, Encryption, 12, 24)
-define_aes_impl!(AesSafe192Decryptor, Decryption, 12, 24)
-define_aes_enc!(AesSafe192Encryptor, 12)
-define_aes_dec!(AesSafe192Decryptor, 12)
+define_aes_struct!(AesSafe192Encryptor, 12);
+define_aes_struct!(AesSafe192Decryptor, 12);
+define_aes_impl!(AesSafe192Encryptor, Encryption, 12, 24);
+define_aes_impl!(AesSafe192Decryptor, Decryption, 12, 24);
+define_aes_enc!(AesSafe192Encryptor, 12);
+define_aes_dec!(AesSafe192Decryptor, 12);
 
-define_aes_struct!(AesSafe256Encryptor, 14)
-define_aes_struct!(AesSafe256Decryptor, 14)
-define_aes_impl!(AesSafe256Encryptor, Encryption, 14, 32)
-define_aes_impl!(AesSafe256Decryptor, Decryption, 14, 32)
-define_aes_enc!(AesSafe256Encryptor, 14)
-define_aes_dec!(AesSafe256Decryptor, 14)
+define_aes_struct!(AesSafe256Encryptor, 14);
+define_aes_struct!(AesSafe256Decryptor, 14);
+define_aes_impl!(AesSafe256Encryptor, Encryption, 14, 32);
+define_aes_impl!(AesSafe256Decryptor, Decryption, 14, 32);
+define_aes_enc!(AesSafe256Encryptor, 14);
+define_aes_dec!(AesSafe256Decryptor, 14);
 
 macro_rules! define_aes_struct_x8(
     (
@@ -241,7 +241,7 @@ macro_rules! define_aes_struct_x8(
             sk: [Bs8State<u32x4>, ..($rounds + 1)]
         }
     )
-)
+);
 
 macro_rules! define_aes_impl_x8(
     (
@@ -268,7 +268,7 @@ macro_rules! define_aes_impl_x8(
             }
         }
     )
-)
+);
 
 macro_rules! define_aes_enc_x8(
     (
@@ -284,7 +284,7 @@ macro_rules! define_aes_enc_x8(
             }
         }
     )
-)
+);
 
 macro_rules! define_aes_dec_x8(
     (
@@ -300,28 +300,28 @@ macro_rules! define_aes_dec_x8(
             }
         }
     )
-)
+);
 
-define_aes_struct_x8!(AesSafe128EncryptorX8, 10)
-define_aes_struct_x8!(AesSafe128DecryptorX8, 10)
-define_aes_impl_x8!(AesSafe128EncryptorX8, Encryption, 10, 16)
-define_aes_impl_x8!(AesSafe128DecryptorX8, Decryption, 10, 16)
-define_aes_enc_x8!(AesSafe128EncryptorX8, 10)
-define_aes_dec_x8!(AesSafe128DecryptorX8, 10)
+define_aes_struct_x8!(AesSafe128EncryptorX8, 10);
+define_aes_struct_x8!(AesSafe128DecryptorX8, 10);
+define_aes_impl_x8!(AesSafe128EncryptorX8, Encryption, 10, 16);
+define_aes_impl_x8!(AesSafe128DecryptorX8, Decryption, 10, 16);
+define_aes_enc_x8!(AesSafe128EncryptorX8, 10);
+define_aes_dec_x8!(AesSafe128DecryptorX8, 10);
 
-define_aes_struct_x8!(AesSafe192EncryptorX8, 12)
-define_aes_struct_x8!(AesSafe192DecryptorX8, 12)
-define_aes_impl_x8!(AesSafe192EncryptorX8, Encryption, 12, 24)
-define_aes_impl_x8!(AesSafe192DecryptorX8, Decryption, 12, 24)
-define_aes_enc_x8!(AesSafe192EncryptorX8, 12)
-define_aes_dec_x8!(AesSafe192DecryptorX8, 12)
+define_aes_struct_x8!(AesSafe192EncryptorX8, 12);
+define_aes_struct_x8!(AesSafe192DecryptorX8, 12);
+define_aes_impl_x8!(AesSafe192EncryptorX8, Encryption, 12, 24);
+define_aes_impl_x8!(AesSafe192DecryptorX8, Decryption, 12, 24);
+define_aes_enc_x8!(AesSafe192EncryptorX8, 12);
+define_aes_dec_x8!(AesSafe192DecryptorX8, 12);
 
-define_aes_struct_x8!(AesSafe256EncryptorX8, 14)
-define_aes_struct_x8!(AesSafe256DecryptorX8, 14)
-define_aes_impl_x8!(AesSafe256EncryptorX8, Encryption, 14, 32)
-define_aes_impl_x8!(AesSafe256DecryptorX8, Decryption, 14, 32)
-define_aes_enc_x8!(AesSafe256EncryptorX8, 14)
-define_aes_dec_x8!(AesSafe256DecryptorX8, 14)
+define_aes_struct_x8!(AesSafe256EncryptorX8, 14);
+define_aes_struct_x8!(AesSafe256DecryptorX8, 14);
+define_aes_impl_x8!(AesSafe256EncryptorX8, Encryption, 14, 32);
+define_aes_impl_x8!(AesSafe256DecryptorX8, Decryption, 14, 32);
+define_aes_enc_x8!(AesSafe256EncryptorX8, 14);
+define_aes_dec_x8!(AesSafe256DecryptorX8, 14);
 
 fn ffmulx(x: u32) -> u32 {
     let m1: u32 = 0x80808080;

--- a/src/rust-crypto/blake2b.rs
+++ b/src/rust-crypto/blake2b.rs
@@ -76,7 +76,7 @@ macro_rules! G( ($r:expr, $i:expr, $a:expr, $b:expr, $c:expr, $d:expr, $m:expr) 
     $d = ($d ^ $a).rotate_right(16);
     $c = $c + $d;
     $b = ($b ^ $c).rotate_right(63);
-}))
+}));
 
 macro_rules! round( ($r:expr, $v:expr, $m:expr) => ( {
     G!($r,0,$v[ 0],$v[ 4],$v[ 8],$v[12], $m);
@@ -88,7 +88,7 @@ macro_rules! round( ($r:expr, $v:expr, $m:expr) => ( {
     G!($r,6,$v[ 2],$v[ 7],$v[ 8],$v[13], $m);
     G!($r,7,$v[ 3],$v[ 4],$v[ 9],$v[14], $m);
   }
-))
+));
 
 impl Blake2b {
     fn set_lastnode(&mut self) {

--- a/src/rust-crypto/cryptoutil.rs
+++ b/src/rust-crypto/cryptoutil.rs
@@ -356,7 +356,7 @@ macro_rules! impl_fixed_buffer( ($name:ident, $size:expr) => (
 
         fn size(&self) -> uint { $size }
     }
-))
+));
 
 /// A fixed size buffer of 64 bytes useful for cryptographic operations.
 #[deriving(Copy)]
@@ -375,7 +375,7 @@ impl FixedBuffer64 {
     }
 }
 
-impl_fixed_buffer!(FixedBuffer64, 64)
+impl_fixed_buffer!(FixedBuffer64, 64);
 
 /// A fixed size buffer of 128 bytes useful for cryptographic operations.
 pub struct FixedBuffer128 {
@@ -393,7 +393,7 @@ impl FixedBuffer128 {
     }
 }
 
-impl_fixed_buffer!(FixedBuffer128, 128)
+impl_fixed_buffer!(FixedBuffer128, 128);
 
 
 /// The StandardPadding trait adds a method useful for various hash algorithms to a FixedBuffer

--- a/src/rust-crypto/ed25519.rs
+++ b/src/rust-crypto/ed25519.rs
@@ -161,7 +161,7 @@ mod tests {
 
         for &(index, flip) in [(0, 1), (31, 0x80), (20, 0xff)].iter() {
             actual_signature[index] ^= flip;
-            assert!(!verify(message, public_key.as_slice(), actual_signature.as_slice()))
+            assert!(!verify(message, public_key.as_slice(), actual_signature.as_slice()));
             actual_signature[index] ^= flip;
         }
 

--- a/src/rust-crypto/ripemd160.rs
+++ b/src/rust-crypto/ripemd160.rs
@@ -51,7 +51,7 @@ macro_rules! round(
         $a = circular_shift($bits, $a) + $e;
         $c = circular_shift(10, $c);
     });
-)
+);
 
 macro_rules! process_block(
     ($h:ident, $data:expr,
@@ -82,27 +82,27 @@ macro_rules! process_block(
         // Round 1
         $( round!(bb[$f0], bb[$f1], bb[$f2], bb[$f3], bb[$f4],
                   $data[$data_index1], $bits1, 0x00000000,
-                  bb[$f1] ^ bb[$f2] ^ bb[$f3]) )*
+                  bb[$f1] ^ bb[$f2] ^ bb[$f3]); )*
 
         // Round 2
         $( round!(bb[$g0], bb[$g1], bb[$g2], bb[$g3], bb[$g4],
                   $data[$data_index2], $bits2, 0x5a827999,
-                  (bb[$g1] & bb[$g2]) | (!bb[$g1] & bb[$g3])) )*
+                  (bb[$g1] & bb[$g2]) | (!bb[$g1] & bb[$g3])); )*
 
         // Round 3
         $( round!(bb[$h0], bb[$h1], bb[$h2], bb[$h3], bb[$h4],
                   $data[$data_index3], $bits3, 0x6ed9eba1,
-                  (bb[$h1] | !bb[$h2]) ^ bb[$h3]) )*
+                  (bb[$h1] | !bb[$h2]) ^ bb[$h3]); )*
 
         // Round 4
         $( round!(bb[$i0], bb[$i1], bb[$i2], bb[$i3], bb[$i4],
                   $data[$data_index4], $bits4, 0x8f1bbcdc,
-                  (bb[$i1] & bb[$i3]) | (bb[$i2] & !bb[$i3])) )*
+                  (bb[$i1] & bb[$i3]) | (bb[$i2] & !bb[$i3])); )*
 
         // Round 5
         $( round!(bb[$j0], bb[$j1], bb[$j2], bb[$j3], bb[$j4],
                   $data[$data_index5], $bits5, 0xa953fd4e,
-                  bb[$j1] ^ (bb[$j2] | !bb[$j3])) )*
+                  bb[$j1] ^ (bb[$j2] | !bb[$j3])); )*
 
         // Parallel rounds: these are the same as the previous five
         // rounds except that the constants have changed, we work
@@ -112,27 +112,27 @@ macro_rules! process_block(
         // Parallel Round 1
         $( round!(bbb[$pj0], bbb[$pj1], bbb[$pj2], bbb[$pj3], bbb[$pj4],
                   $data[$pdata_index1], $pbits1, 0x50a28be6,
-                  bbb[$pj1] ^ (bbb[$pj2] | !bbb[$pj3])) )*
+                  bbb[$pj1] ^ (bbb[$pj2] | !bbb[$pj3])); )*
 
         // Parallel Round 2
         $( round!(bbb[$pi0], bbb[$pi1], bbb[$pi2], bbb[$pi3], bbb[$pi4],
                   $data[$pdata_index2], $pbits2, 0x5c4dd124,
-                  (bbb[$pi1] & bbb[$pi3]) | (bbb[$pi2] & !bbb[$pi3])) )*
+                  (bbb[$pi1] & bbb[$pi3]) | (bbb[$pi2] & !bbb[$pi3])); )*
 
         // Parallel Round 3
         $( round!(bbb[$ph0], bbb[$ph1], bbb[$ph2], bbb[$ph3], bbb[$ph4],
                   $data[$pdata_index3], $pbits3, 0x6d703ef3,
-                  (bbb[$ph1] | !bbb[$ph2]) ^ bbb[$ph3]) )*
+                  (bbb[$ph1] | !bbb[$ph2]) ^ bbb[$ph3]); )*
 
         // Parallel Round 4
         $( round!(bbb[$pg0], bbb[$pg1], bbb[$pg2], bbb[$pg3], bbb[$pg4],
                   $data[$pdata_index4], $pbits4, 0x7a6d76e9,
-                  (bbb[$pg1] & bbb[$pg2]) | (!bbb[$pg1] & bbb[$pg3])) )*
+                  (bbb[$pg1] & bbb[$pg2]) | (!bbb[$pg1] & bbb[$pg3])); )*
 
         // Parallel Round 5
         $( round!(bbb[$pf0], bbb[$pf1], bbb[$pf2], bbb[$pf3], bbb[$pf4],
                   $data[$pdata_index5], $pbits5, 0x00000000,
-                  bbb[$pf1] ^ bbb[$pf2] ^ bbb[$pf3]) )*
+                  bbb[$pf1] ^ bbb[$pf2] ^ bbb[$pf3]); )*
 
         // Combine results
         bbb[3] += $h[1] + bb[2];
@@ -142,7 +142,7 @@ macro_rules! process_block(
         $h[4]   = $h[0] + bb[1] + bbb[2];
         $h[0]   =                 bbb[3];
     });
-)
+);
 
 fn process_msg_block(data: &[u8], h: &mut [u32, ..DIGEST_BUF_LEN]) {
     let mut w = [0u32, ..WORK_BUF_LEN];

--- a/src/rust-crypto/scrypt.rs
+++ b/src/rust-crypto/scrypt.rs
@@ -38,7 +38,7 @@ fn salsa20_8(input: &[u8], output: &mut [u8]) {
         ($($set_idx:expr, $idx_a:expr, $idx_b:expr, $rot:expr);*) => { {
             $( x[$set_idx] ^= (x[$idx_a] + x[$idx_b]).rotate_left($rot); )*
         } }
-    )
+    );
 
     for _ in range(0u, rounds / 2) {
         run_round!(

--- a/src/rust-crypto/sha2.rs
+++ b/src/rust-crypto/sha2.rs
@@ -93,7 +93,7 @@ impl Engine512State {
         macro_rules! schedule_round( ($t:expr) => (
                 w[$t] = sigma1(w[$t - 2]) + w[$t - 7] + sigma0(w[$t - 15]) + w[$t - 16];
                 )
-        )
+        );
 
         macro_rules! sha2_round(
             ($A:ident, $B:ident, $C:ident, $D:ident,
@@ -104,7 +104,7 @@ impl Engine512State {
                     $H += sum0($A) + maj($A, $B, $C);
                 }
              )
-        )
+        );
 
 
         read_u64v_be(w[mut 0..16], data);
@@ -205,7 +205,7 @@ impl Engine512 {
     }
 
     fn input(&mut self, input: &[u8]) {
-        assert!(!self.finished)
+        assert!(!self.finished);
         // Assumes that input.len() can be converted to u64 without overflow
         self.length_bits = add_bytes_to_bits_tuple(self.length_bits, input.len() as u64);
         let self_state = &mut self.state;
@@ -522,7 +522,7 @@ impl Engine256State {
         macro_rules! schedule_round( ($t:expr) => (
                 w[$t] = sigma1(w[$t - 2]) + w[$t - 7] + sigma0(w[$t - 15]) + w[$t - 16];
                 )
-        )
+        );
 
         macro_rules! sha2_round(
             ($A:ident, $B:ident, $C:ident, $D:ident,
@@ -533,7 +533,7 @@ impl Engine256State {
                     $H += sum0($A) + maj($A, $B, $C);
                 }
              )
-        )
+        );
 
 
         read_u32v_be(w[mut 0..16], data);
@@ -630,7 +630,7 @@ impl Engine256 {
     }
 
     fn input(&mut self, input: &[u8]) {
-        assert!(!self.finished)
+        assert!(!self.finished);
         // Assumes that input.len() can be converted to u64 without overflow
         self.length_bits = add_bytes_to_bits(self.length_bits, input.len() as u64);
         let self_state = &mut self.state;

--- a/src/rust-crypto/util.rs
+++ b/src/rust-crypto/util.rs
@@ -17,11 +17,11 @@ pub fn supports_aesni() -> bool {
         : "=r" (flags) // output
         : // input
         : "eax", "ebx", "ecx", "edx" // clobbers
-        )
+        );
 		// No idea why, but on 32-bit targets, the compiler complains
 		// about not having enough registers. Adding in this dummy
 		// section, however, seems to fix it.
-        asm!("")
+        asm!("");
     }
 
     (flags & 0x02000000) != 0


### PR DESCRIPTION
To fix the build on most recent nightly of rustc.
