### PR TITLE
aes::ctr().process() would infinite loop

### DIFF
--- a/src/rust-crypto/symmetriccipher.rs
+++ b/src/rust-crypto/symmetriccipher.rs
@@ -50,7 +50,8 @@ pub trait SynchronousStreamCipher {
 // TODO - Its a bit unclear to me why this is necessary
 impl SynchronousStreamCipher for Box<SynchronousStreamCipher + 'static> {
     fn process(&mut self, input: &[u8], output: &mut [u8]) {
-        self.process(input, output);
+        let me = &mut **self;
+        me.process(input, output);
     }
 }
 


### PR DESCRIPTION
The SynchronousStreamCipher implementation on boxed SynchronousStreamCiphers
just calls the process method on the underlying SynchronousStreamCipher
trait object. In older Rust versions, I believed that this worked. It
doesn't work now - it just calls itself and infinite loops until the
stack is oveflowed. Unfortunately, there wasn't a test that caught this.
This fixes the underlying problem and adds a test.
