### PR TITLE
Fix an inference failure (`fn found, different fn expected.`)

### DIFF
--- a/src/rust-crypto/aesni.rs
+++ b/src/rust-crypto/aesni.rs
@@ -20,9 +20,12 @@ pub struct AesNiDecryptor {
     round_keys: [u8, ..240]
 }
 
+/// The number of rounds as well as a function to setup an appropriately sized key.
+type RoundSetupInfo = (uint, fn(&[u8], KeyType, &mut [u8]));
+
 impl AesNiEncryptor {
     pub fn new(key_size: KeySize, key: &[u8]) -> AesNiEncryptor {
-        let (rounds, setup_function) = match key_size {
+        let (rounds, setup_function): RoundSetupInfo = match key_size {
             KeySize128 => (10, setup_working_key_aesni_128),
             KeySize192 => (12, setup_working_key_aesni_192),
             KeySize256 => (14, setup_working_key_aesni_256)
@@ -38,7 +41,7 @@ impl AesNiEncryptor {
 
 impl AesNiDecryptor {
     pub fn new(key_size: KeySize, key: &[u8]) -> AesNiDecryptor {
-        let (rounds, setup_function) = match key_size {
+        let (rounds, setup_function): RoundSetupInfo = match key_size {
             KeySize128 => (10, setup_working_key_aesni_128),
             KeySize192 => (12, setup_working_key_aesni_192),
             KeySize256 => (14, setup_working_key_aesni_256)


### PR DESCRIPTION
Using the latest nightly (mozilla/rust@62fb41c32) I get an error such as:

```
rc/rust-crypto/aesni.rs:25:40: 29:10 error: match arms have incompatible types: expected `(_, fn(&[u8], aesni::KeyType, &mut [u8]) {aesni::setup_working_key_aesni_128})`, found `(_, fn(&[u8], aesni::KeyType, &mut [u8]) {aesni::setup_working_key_aesni_192})` (expected fn item, found a different fn item)
src/rust-crypto/aesni.rs:25         let (rounds, setup_function) = match key_size {
src/rust-crypto/aesni.rs:26             KeySize128 => (10, setup_working_key_aesni_128),
src/rust-crypto/aesni.rs:27             KeySize192 => (12, setup_working_key_aesni_192),
src/rust-crypto/aesni.rs:28             KeySize256 => (14, setup_working_key_aesni_256)
src/rust-crypto/aesni.rs:29         };
src/rust-crypto/aesni.rs:27:27: 27:61 note: match arm with an incompatible type
src/rust-crypto/aesni.rs:27             KeySize192 => (12, setup_working_key_aesni_192),
                                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/rust-crypto/aesni.rs:34:9: 34:23 error: the type of this value must be known in this context
src/rust-crypto/aesni.rs:34         setup_function(key, KeyType::Encryption, e.round_keys.slice_mut(0, size(e.rounds)));
                                    ^~~~~~~~~~~~~~
src/rust-crypto/aesni.rs:34:9: 34:92 error: this function takes 1 parameter but 3 parameters were supplied [E0057]
src/rust-crypto/aesni.rs:34         setup_function(key, KeyType::Encryption, e.round_keys.slice_mut(0, size(e.rounds)));
```

I _believe_ this is introduced by [rust PR#19891](https://github.com/rust-lang/rust/pull/19891)

If you look closely you'll see rustc has tagged the expected fn-ptr with the name of the function from the first match-arm: `expected``(_, fn(&[u8], aesni::KeyType, &mut [u8]) {aesni::setup_working_key_aesni_128})`` ` 

This patch declares a type _without that tag_ and then uses that type in lieu of the inference.
Reading that PR: I do think we need to be explicit about the expected type here to trigger the coercion we want.
