### PR TITLE
Depend on rustc-serialize from crates.io since Rust's in-tree serialize crate has been deprecated

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,4 @@ opt-level = 2
 
 [dependencies]
 time = "*"
+rustc-serialize = "*"

--- a/src/rust-crypto/lib.rs
+++ b/src/rust-crypto/lib.rs
@@ -9,7 +9,7 @@
 #![feature(simd)]
 #![feature(slicing_syntax)]
 
-extern crate serialize;
+extern crate "rustc-serialize" as serialize;
 extern crate time;
 #[cfg(test)] extern crate test;
 


### PR DESCRIPTION
This also fixes a problem where depending on serialize would pull
in the also deprecated log and regex crates from the Rust distribution
instead of their Crates.io versions. This could lead to dependency
issues for projects using Rust-Crypto that needed to use the
Crates.io versions of those libraries.

Closes #189
