### PR TITLE
Fix mutable slice syntax ...

### DIFF
--- a/src/rust-crypto/aes.rs
+++ b/src/rust-crypto/aes.rs
@@ -696,7 +696,7 @@ mod test {
         for test in tests.iter() {
             let mut aes_enc = aes::ctr(aes::KeySize::KeySize128, test.key[], test.ctr[]);
             let mut result: Vec<u8> = Vec::from_elem(test.plain.len(), 0);
-            aes_enc.process(test.plain[], result[mut]);
+            aes_enc.process(test.plain[], result.as_mut_slice());
             assert!(result.as_slice() == test.cipher);
         }
     }

--- a/src/rust-crypto/aessafe.rs
+++ b/src/rust-crypto/aessafe.rs
@@ -600,10 +600,10 @@ fn un_bit_slice_4x1_with_u32(bs: &Bs8State<u32>) -> u32 {
 fn un_bit_slice_1x16_with_u32(bs: &Bs8State<u32>, output: &mut [u8]) {
     let (a, b, c, d) = un_bit_slice_4x4_with_u32(bs);
 
-    write_u32_le(output[mut 0..4], a);
-    write_u32_le(output[mut 4..8], b);
-    write_u32_le(output[mut 8..12], c);
-    write_u32_le(output[mut 12..16], d);
+    write_u32_le(output.slice_mut(0,4), a);
+    write_u32_le(output.slice_mut(4,8), b);
+    write_u32_le(output.slice_mut(8,12), c);
+    write_u32_le(output.slice_mut(12,16), d);
 }
 
 // Bit Slice a 128 byte array of eight 16 byte blocks. Each block is in column major order.
@@ -671,10 +671,10 @@ fn bit_slice_1x128_with_u32x4(data: &[u8]) -> Bs8State<u32x4> {
 fn bit_slice_fill_4x4_with_u32x4(a: u32, b: u32, c: u32, d: u32) -> Bs8State<u32x4> {
     let mut tmp = [0u8, ..128];
     for i in range(0u, 8) {
-        write_u32_le(tmp[mut i * 16..i * 16 + 4], a);
-        write_u32_le(tmp[mut i * 16 + 4..i * 16 + 8], b);
-        write_u32_le(tmp[mut i * 16 + 8..i * 16 + 12], c);
-        write_u32_le(tmp[mut i * 16 + 12..i * 16 + 16], d);
+        write_u32_le(tmp.slice_mut(i * 16,i * 16 + 4), a);
+        write_u32_le(tmp.slice_mut(i * 16 + 4,i * 16 + 8), b);
+        write_u32_le(tmp.slice_mut(i * 16 + 8,i * 16 + 12), c);
+        write_u32_le(tmp.slice_mut(i * 16 + 12,i * 16 + 16), d);
     }
     return bit_slice_1x128_with_u32x4(&tmp);
 }
@@ -731,14 +731,14 @@ fn un_bit_slice_1x128_with_u32x4(bs: &Bs8State<u32x4>, output: &mut [u8]) {
         output[15] = (a3 >> 24) as u8;
     }
 
-    write_row_major(&x0, output[mut 0..16]);
-    write_row_major(&x1, output[mut 16..32]);
-    write_row_major(&x2, output[mut 32..48]);
-    write_row_major(&x3, output[mut 48..64]);
-    write_row_major(&x4, output[mut 64..80]);
-    write_row_major(&x5, output[mut 80..96]);
-    write_row_major(&x6, output[mut 96..112]);
-    write_row_major(&x7, output[mut 112..128])
+    write_row_major(&x0, output.slice_mut(0,16));
+    write_row_major(&x1, output.slice_mut(16,32));
+    write_row_major(&x2, output.slice_mut(32,48));
+    write_row_major(&x3, output.slice_mut(48,64));
+    write_row_major(&x4, output.slice_mut(64,80));
+    write_row_major(&x5, output.slice_mut(80,96));
+    write_row_major(&x6, output.slice_mut(96,112));
+    write_row_major(&x7, output.slice_mut(112,128))
 }
 
 // The Gf2Ops, Gf4Ops, and Gf8Ops traits specify the functions needed to calculate the AES S-Box

--- a/src/rust-crypto/bcrypt.rs
+++ b/src/rust-crypto/bcrypt.rs
@@ -34,8 +34,8 @@ pub fn bcrypt(cost: uint, salt: &[u8], password: &[u8], output: &mut [u8]) {
             ctext[i] = l;
             ctext[i+1] = r;
         }
-        write_u32_be(output[mut i*4..(i+1)*4], ctext[i]);
-        write_u32_be(output[mut (i+1)*4..(i+2)*4], ctext[i+1]);
+        write_u32_be(output.slice_mut(i*4,(i+1)*4), ctext[i]);
+        write_u32_be(output.slice_mut((i+1)*4,(i+2)*4), ctext[i+1]);
     }
 }
 
@@ -140,7 +140,7 @@ mod test {
         let tests = openwall_test_vectors();
         let mut output = [0u8, ..24];
         for test in tests.iter() {
-            bcrypt(test.cost, test.salt[], test.input[], output[mut]);
+            bcrypt(test.cost, test.salt[], test.input[], output.as_mut_slice());
             assert_eq!(output[0..23], test.output[]);
         }
     }

--- a/src/rust-crypto/bcrypt_pbkdf.rs
+++ b/src/rust-crypto/bcrypt_pbkdf.rs
@@ -48,13 +48,13 @@ pub fn bcrypt_pbkdf(password: &[u8], salt: &[u8], rounds: uint, output: &mut [u8
 
     let mut h = Sha512::new();
     h.input(password);
-    h.result(hpass[mut]);
+    h.result(hpass.as_mut_slice());
 
     for block in range(1u, (nblocks+1)) {
         let mut count = [0u8, ..4];
         let mut hsalt = [0u8, ..64];
         let mut out   = [0u8, ..32];
-        write_u32_be(count[mut], block as u32);
+        write_u32_be(count.as_mut_slice(), block as u32);
 
         h.reset();
         h.input(salt);
@@ -257,7 +257,7 @@ mod test {
 
         for t in tests.iter() {
             let mut out = Vec::from_elem(t.out.len(), 0u8);
-            bcrypt_pbkdf(t.password[], t.salt[], t.rounds, out[mut]);
+            bcrypt_pbkdf(t.password[], t.salt[], t.rounds, out.as_mut_slice());
             assert_eq!(out, t.out);
         }
     }
@@ -275,7 +275,7 @@ mod bench {
         let mut out  = [0u8, ..32];
 
         b.iter(|| {
-            bcrypt_pbkdf(&pass, &salt, 5, out[mut]);
+            bcrypt_pbkdf(&pass, &salt, 5, out.as_mut_slice());
         });
     }
 }

--- a/src/rust-crypto/blake2b.rs
+++ b/src/rust-crypto/blake2b.rs
@@ -253,7 +253,7 @@ impl Blake2b {
             let fill = 2 * BLAKE2B_BLOCKBYTES - left;
 
             if input.len() > fill {
-                copy_memory( self.buf[mut left..], input[0..fill] ); // Fill buffer
+                copy_memory( self.buf.slice_from_mut(left), input[0..fill] ); // Fill buffer
                 self.buflen += fill;
                 self.increment_counter( BLAKE2B_BLOCKBYTES as u64);
                 self.compress();
@@ -266,7 +266,7 @@ impl Blake2b {
                 self.buflen -= BLAKE2B_BLOCKBYTES;
                 input = input[fill..input.len()];
             } else { // inlen <= fill
-                copy_memory(self.buf[mut left..], input);
+                copy_memory(self.buf.slice_from_mut(left), input);
                 self.buflen += input.len();
                 break;
             }
@@ -291,12 +291,12 @@ impl Blake2b {
             self.increment_counter(incby);
             self.set_lastblock();
 
-            for b in self.buf[mut self.buflen..].iter_mut() {
+            for b in self.buf.slice_from_mut(self.buflen).iter_mut() {
                 *b = 0;
             }
             self.compress();
 
-            write_u64v_le(self.buf[mut 0..64], &self.h);
+            write_u64v_le(self.buf.slice_mut(0,64), &self.h);
             self.computed = true;
         }
         let outlen = out.len();
@@ -379,7 +379,7 @@ impl Mac for Blake2b {
      */
     fn result(&mut self) -> MacResult {
         let mut mac : Vec<u8> = Vec::from_fn(self.digest_length as uint, |_| 0);
-        self.raw_result(mac[mut]);
+        self.raw_result(mac.as_mut_slice());
         MacResult::new_from_owned(mac)
     }
 

--- a/src/rust-crypto/blowfish.rs
+++ b/src/rust-crypto/blowfish.rs
@@ -315,10 +315,10 @@ impl BlockEncryptor for Blowfish {
         assert!(input.len() == 8);
         assert!(output.len() == 8);
         let mut block = [0u32, 0u32];
-        read_u32v_be(block[mut], input);
+        read_u32v_be(block.as_mut_slice(), input);
         let (l, r) = self.encrypt(block[0], block[1]);
-        write_u32_be(output[mut 0..4], l);
-        write_u32_be(output[mut 4..8], r);
+        write_u32_be(output.slice_mut(0,4), l);
+        write_u32_be(output.slice_mut(4,8), r);
     }
 }
 
@@ -331,10 +331,10 @@ impl BlockDecryptor for Blowfish {
         assert!(input.len() == 8);
         assert!(output.len() == 8);
         let mut block = [0u32, 0u32];
-        read_u32v_be(block[mut], input);
+        read_u32v_be(block.as_mut_slice(), input);
         let (l, r) = self.decrypt(block[0], block[1]);
-        write_u32_be(output[mut 0..4], l);
-        write_u32_be(output[mut 4..8], r);
+        write_u32_be(output.slice_mut(0,4), l);
+        write_u32_be(output.slice_mut(4,8), r);
     }
 }
 
@@ -529,7 +529,7 @@ mod test {
         let mut output = [0u8, ..8];
         for test in tests.iter() {
             let state = Blowfish::new(test.key[]);
-            state.encrypt_block(test.plaintext[], output[mut]);
+            state.encrypt_block(test.plaintext[], output.as_mut_slice());
             assert!(test.ciphertext[] == output[]);
         }
     }
@@ -540,7 +540,7 @@ mod test {
         let mut output = [0u8, ..8];
         for test in tests.iter() {
             let state = Blowfish::new(test.key[]);
-            state.decrypt_block(test.ciphertext[], output[mut]);
+            state.decrypt_block(test.ciphertext[], output.as_mut_slice());
             assert!(test.plaintext[] == output[]);
         }
     }

--- a/src/rust-crypto/buffer.rs
+++ b/src/rust-crypto/buffer.rs
@@ -175,16 +175,16 @@ impl <'a> WriteBuffer for RefWriteBuffer<'a> {
     fn reset(&mut self) { self.pos = 0; }
 
     fn peek_read_buffer(&mut self) -> RefReadBuffer {
-        RefReadBuffer::new(self.buff[mut ..self.pos])
+        RefReadBuffer::new(self.buff.slice_to_mut(self.pos))
     }
 
     fn take_next(&mut self, count: uint) -> &mut [u8] {
-        let r = self.buff[mut self.pos..self.pos + count];
+        let r = self.buff.slice_mut(self.pos,self.pos + count);
         self.pos += count;
         r
     }
     fn take_read_buffer(&mut self) -> RefReadBuffer {
-        let r = RefReadBuffer::new(self.buff[mut ..self.pos]);
+        let r = RefReadBuffer::new(self.buff.slice_to_mut(self.pos));
         self.pos = 0;
         r
     }
@@ -227,7 +227,7 @@ impl <'a> WriteBuffer for BorrowedWriteBuffer<'a> {
     }
 
     fn take_next<>(&mut self, count: uint) -> &mut [u8] {
-        let r = self.parent.buff[mut self.pos..self.pos + count];
+        let r = self.parent.buff.slice_mut(self.pos,self.pos + count);
         self.pos += count;
         self.parent.len += count;
         r
@@ -275,7 +275,7 @@ impl WriteBuffer for OwnedWriteBuffer {
     }
 
     fn take_next<'a>(&'a mut self, count: uint) -> &'a mut [u8] {
-        let r = self.buff[mut self.pos..self.pos + count];
+        let r = self.buff.slice_mut(self.pos,self.pos + count);
         self.pos += count;
         r
     }

--- a/src/rust-crypto/chacha20.rs
+++ b/src/rust-crypto/chacha20.rs
@@ -127,7 +127,7 @@ impl ChaCha20 {
             d1,d2,d3,d4
         ];
         for i in range(0, lens.len()) {
-            write_u32_le(self.output[mut i*4..(i+1)*4], lens[i]);
+            write_u32_le(self.output.slice_mut(i*4,(i+1)*4), lens[i]);
         }
 
         self.state.d += u32x4(1, 0, 0, 0);
@@ -308,7 +308,7 @@ mod test {
             let mut c = ChaCha20::new(&tv.key, &tv.nonce);
             let input = Vec::from_elem(tv.keystream.len(), 0u8);
             let mut output = Vec::from_elem(input.len(), 0u8);
-            c.process(input[], output[mut]);
+            c.process(input[], output.as_mut_slice());
             assert_eq!(output, tv.keystream);
         }
     }

--- a/src/rust-crypto/cryptoutil.rs
+++ b/src/rust-crypto/cryptoutil.rs
@@ -292,14 +292,14 @@ macro_rules! impl_fixed_buffer( ($name:ident, $size:expr) => (
                 let buffer_remaining = size - self.buffer_idx;
                 if input.len() >= buffer_remaining {
                         copy_memory(
-                            self.buffer[mut self.buffer_idx..size],
+                            self.buffer.slice_mut(self.buffer_idx,size),
                             input[..buffer_remaining]);
                     self.buffer_idx = 0;
                     func(&self.buffer);
                     i += buffer_remaining;
                 } else {
                     copy_memory(
-                        self.buffer[mut self.buffer_idx..self.buffer_idx + input.len()],
+                        self.buffer.slice_mut(self.buffer_idx,self.buffer_idx + input.len()),
                         input);
                     self.buffer_idx += input.len();
                     return;
@@ -318,7 +318,7 @@ macro_rules! impl_fixed_buffer( ($name:ident, $size:expr) => (
             // be empty.
             let input_remaining = input.len() - i;
             copy_memory(
-                self.buffer[mut 0..input_remaining],
+                self.buffer.slice_mut(0,input_remaining),
                 input[i..]);
             self.buffer_idx += input_remaining;
         }
@@ -329,13 +329,13 @@ macro_rules! impl_fixed_buffer( ($name:ident, $size:expr) => (
 
         fn zero_until(&mut self, idx: uint) {
             assert!(idx >= self.buffer_idx);
-            self.buffer[mut self.buffer_idx..idx].set_memory(0);
+            self.buffer.slice_mut(self.buffer_idx,idx).set_memory(0);
             self.buffer_idx = idx;
         }
 
         fn next<'s>(&'s mut self, len: uint) -> &'s mut [u8] {
             self.buffer_idx += len;
-            return self.buffer[mut self.buffer_idx - len..self.buffer_idx];
+            return self.buffer.slice_mut(self.buffer_idx - len,self.buffer_idx);
         }
 
         fn full_buffer<'s>(&'s mut self) -> &'s [u8] {

--- a/src/rust-crypto/digest.rs
+++ b/src/rust-crypto/digest.rs
@@ -73,7 +73,7 @@ pub trait Digest {
         use serialize::hex::ToHex;
 
         let mut buf = Vec::from_elem((self.output_bits()+7)/8, 0u8);
-        self.result(buf[mut]);
+        self.result(buf.as_mut_slice());
         return buf[].to_hex();
     }
 }

--- a/src/rust-crypto/ghash.rs
+++ b/src/rust-crypto/ghash.rs
@@ -45,10 +45,10 @@ impl Gf128 {
         let simd::u32x4(a, b, c, d) = self.d;
         let mut result: [u8, ..16] = unsafe { mem::uninitialized() };
 
-        write_u32_be(result[mut 0..4], d);
-        write_u32_be(result[mut 4..8], c);
-        write_u32_be(result[mut 8..12], b);
-        write_u32_be(result[mut 12..16], a);
+        write_u32_be(result.slice_mut(0,4), d);
+        write_u32_be(result.slice_mut(4,8), c);
+        write_u32_be(result.slice_mut(8,12), b);
+        write_u32_be(result.slice_mut(12,16), a);
 
         result
     }
@@ -157,13 +157,13 @@ fn update(state: &mut Gf128, len: &mut uint, data: &[u8], srest: &mut Option<[u8
         None => data,
         Some(mut rest) => {
             if 16 - rest_len > data_len {
-                copy_memory(rest[mut rest_len..], data);
+                copy_memory(rest.slice_from_mut(rest_len), data);
                 *srest = Some(rest);
                 return;
             }
 
             let (fill, data) = data.split_at(16 - rest_len);
-            copy_memory(rest[mut rest_len..], fill);
+            copy_memory(rest.slice_from_mut(rest_len), fill);
             state.add_and_mul(Gf128::from_bytes(&rest), hs);
             data
         }
@@ -296,7 +296,7 @@ impl Mac for Ghash {
 
     fn result(&mut self) -> MacResult {
         let mut mac = [0u8, ..16];
-        self.raw_result(mac[mut]);
+        self.raw_result(mac.as_mut_slice());
         return MacResult::new(mac[]);
     }
 
@@ -569,7 +569,7 @@ mod bench {
         bh.iter( || {
             let mut ghash = Ghash::new(&key);
             ghash.input(&bytes);
-            ghash.raw_result(mac[mut]);
+            ghash.raw_result(mac.as_mut_slice());
         });
         bh.bytes = bytes.len() as u64;
     }
@@ -582,7 +582,7 @@ mod bench {
         bh.iter( || {
             let mut ghash = Ghash::new(&key);
             ghash.input(&bytes);
-            ghash.raw_result(mac[mut]);
+            ghash.raw_result(mac.as_mut_slice());
         });
         bh.bytes = bytes.len() as u64;
     }
@@ -595,7 +595,7 @@ mod bench {
         bh.iter( || {
             let mut ghash = Ghash::new(&key);
             ghash.input(&bytes);
-            ghash.raw_result(mac[mut]);
+            ghash.raw_result(mac.as_mut_slice());
         });
         bh.bytes = bytes.len() as u64;
     }

--- a/src/rust-crypto/hmac.rs
+++ b/src/rust-crypto/hmac.rs
@@ -36,11 +36,11 @@ fn expand_key<D: Digest>(digest: &mut D, key: &[u8]) -> Vec<u8> {
     let bs = digest.block_size();
     let mut expanded_key = Vec::from_elem(bs, 0u8);
     if key.len() <= bs {
-        slice::bytes::copy_memory(expanded_key[mut], key);
+        slice::bytes::copy_memory(expanded_key.as_mut_slice(), key);
     } else {
         let output_size = digest.output_bytes();
         digest.input(key);
-        digest.result(expanded_key[mut ..output_size]);
+        digest.result(expanded_key.slice_to_mut(output_size));
         digest.reset();
     }
     return expanded_key;
@@ -51,8 +51,8 @@ fn expand_key<D: Digest>(digest: &mut D, key: &[u8]) -> Vec<u8> {
 fn create_keys<D: Digest>(digest: &mut D, key: &[u8]) -> (Vec<u8>, Vec<u8>) {
     let mut i_key = expand_key(digest, key);
     let mut o_key = i_key.clone();
-    derive_key(i_key[mut], 0x36);
-    derive_key(o_key[mut], 0x5c);
+    derive_key(i_key.as_mut_slice(), 0x36);
+    derive_key(o_key.as_mut_slice(), 0x5c);
     return (i_key, o_key);
 }
 
@@ -93,7 +93,7 @@ impl <D: Digest> Mac for Hmac<D> {
         let output_size = self.digest.output_bytes();
         let mut code = Vec::from_elem(output_size, 0u8);
 
-        self.raw_result(code[mut]);
+        self.raw_result(code.as_mut_slice());
 
         return MacResult::new_from_owned(code);
     }

--- a/src/rust-crypto/md5.rs
+++ b/src/rust-crypto/md5.rs
@@ -199,10 +199,10 @@ impl Digest for Md5 {
             self.finished = true;
         }
 
-        write_u32_le(out[mut 0..4], self.state.s0);
-        write_u32_le(out[mut 4..8], self.state.s1);
-        write_u32_le(out[mut 8..12], self.state.s2);
-        write_u32_le(out[mut 12..16], self.state.s3);
+        write_u32_le(out.slice_mut(0,4), self.state.s0);
+        write_u32_le(out.slice_mut(4,8), self.state.s1);
+        write_u32_le(out.slice_mut(8,12), self.state.s2);
+        write_u32_le(out.slice_mut(12,16), self.state.s3);
     }
 
     fn output_bits(&self) -> uint { 128 }

--- a/src/rust-crypto/pbkdf2.rs
+++ b/src/rust-crypto/pbkdf2.rs
@@ -98,10 +98,10 @@ pub fn pbkdf2<M: Mac>(mac: &mut M, salt: &[u8], c: u32, output: &mut [u8]) {
         idx = idx.checked_add(1).expect("PBKDF2 size limit exceeded.");
 
         if chunk.len() == os {
-            calculate_block(mac, salt, c, idx, scratch[mut], chunk);
+            calculate_block(mac, salt, c, idx, scratch.as_mut_slice(), chunk);
         } else {
             let mut tmp = Vec::from_elem(os, 0u8);
-            calculate_block(mac, salt, c, idx, scratch[mut], tmp[mut]);
+            calculate_block(mac, salt, c, idx, scratch.as_mut_slice(), tmp.as_mut_slice());
             chunk.clone_from_slice(tmp[]);
         }
     }
@@ -236,7 +236,7 @@ pub fn pbkdf2_check(password: &str, hashed_value: &str) -> Result<bool, &'static
     let mut mac = Hmac::new(Sha256::new(), password.as_bytes());
 
     let mut output = Vec::from_elem(hash.len(), 0u8);
-    pbkdf2(&mut mac, salt[], c, output[mut]);
+    pbkdf2(&mut mac, salt[], c, output.as_mut_slice());
 
     // Be careful here - its important that the comparison be done using a fixed time equality
     // check. Otherwise an adversary that can measure how long this step takes can learn about the
@@ -316,7 +316,7 @@ mod test {
         for t in tests.iter() {
             let mut mac = Hmac::new(Sha1::new(), t.password[]);
             let mut result = Vec::from_elem(t.expected.len(), 0u8);
-            pbkdf2(&mut mac, t.salt[], t.c, result[mut]);
+            pbkdf2(&mut mac, t.salt[], t.c, result.as_mut_slice());
             assert!(result == t.expected);
         }
     }

--- a/src/rust-crypto/poly1305.rs
+++ b/src/rust-crypto/poly1305.rs
@@ -203,7 +203,7 @@ impl Mac for Poly1305 {
 
     fn result(&mut self) -> MacResult {
         let mut mac = [0u8, ..16];
-        self.raw_result(mac[mut]);
+        self.raw_result(mac.as_mut_slice());
         return MacResult::new(mac[]);
     }
 
@@ -212,10 +212,10 @@ impl Mac for Poly1305 {
         if !self.finalized{
             self.finish();
         }
-        write_u32_le(output[mut 0..4], self.h[0]);
-        write_u32_le(output[mut 4..8], self.h[1]);
-        write_u32_le(output[mut 8..12], self.h[2]);
-        write_u32_le(output[mut 12..16], self.h[3]);
+        write_u32_le(output.slice_mut(0,4), self.h[0]);
+        write_u32_le(output.slice_mut(4,8), self.h[1]);
+        write_u32_le(output.slice_mut(8,12), self.h[2]);
+        write_u32_le(output.slice_mut(12,16), self.h[3]);
     }
 
     fn output_bytes(&self) -> uint { 16 }
@@ -267,7 +267,7 @@ mod test {
         ];
 
         let mut mac = [0u8, ..16];
-        poly1305(&key, &msg, mac[mut]);
+        poly1305(&key, &msg, mac.as_mut_slice());
         assert_eq!(mac[], expected[]);
 
         let mut poly = Poly1305::new(&key);
@@ -282,7 +282,7 @@ mod test {
         poly.input(msg[128..129]);
         poly.input(msg[129..130]);
         poly.input(msg[130..131]);
-        poly.raw_result(mac[mut]);
+        poly.raw_result(mac.as_mut_slice());
         assert_eq!(mac[], expected[]);
     }
 
@@ -306,7 +306,7 @@ mod test {
         ];
 
         let mut mac = [0u8, ..16];
-        poly1305(&wrap_key, &wrap_msg, mac[mut]);
+        poly1305(&wrap_key, &wrap_msg, mac.as_mut_slice());
         assert_eq!(mac[], wrap_mac[]);
 
         let total_key = [
@@ -343,7 +343,7 @@ mod test {
             0xc2, 0x6b, 0x33, 0xb9, 0x1c, 0xcc, 0x03, 0x07,
         ];
         let mut mac = [0u8, ..16];
-        poly1305(key, &msg, mac[mut]);
+        poly1305(key, &msg, mac.as_mut_slice());
         assert_eq!(mac[], expected[]);
 
         let msg = b"Hello world!";
@@ -351,7 +351,7 @@ mod test {
             0xa6, 0xf7, 0x45, 0x00, 0x8f, 0x81, 0xc9, 0x16,
             0xa2, 0x0d, 0xcc, 0x74, 0xee, 0xf2, 0xb2, 0xf0,
         ];
-        poly1305(key, msg, mac[mut]);
+        poly1305(key, msg, mac.as_mut_slice());
         assert_eq!(mac[], expected[]);
     }
 }
@@ -370,7 +370,7 @@ mod bench {
         bh.iter( || {
             let mut poly = Poly1305::new(&key);
             poly.input(&bytes);
-            poly.raw_result(mac[mut]);
+            poly.raw_result(mac.as_mut_slice());
         });
         bh.bytes = bytes.len() as u64;
     }
@@ -383,7 +383,7 @@ mod bench {
         bh.iter( || {
             let mut poly = Poly1305::new(&key);
             poly.input(&bytes);
-            poly.raw_result(mac[mut]);
+            poly.raw_result(mac.as_mut_slice());
         });
         bh.bytes = bytes.len() as u64;
     }
@@ -396,7 +396,7 @@ mod bench {
         bh.iter( || {
             let mut poly = Poly1305::new(&key);
             poly.input(&bytes);
-            poly.raw_result(mac[mut]);
+            poly.raw_result(mac.as_mut_slice());
         });
         bh.bytes = bytes.len() as u64;
     }

--- a/src/rust-crypto/rc4.rs
+++ b/src/rust-crypto/rc4.rs
@@ -104,7 +104,7 @@ mod test {
         for t in tests.iter() {
             let mut rc4 = Rc4::new(t.key.as_bytes());
             let mut result = Vec::from_elem(t.output.len(), 0u8);
-            rc4.process(t.input.as_bytes(), result[mut]);
+            rc4.process(t.input.as_bytes(), result.as_mut_slice());
             assert!(result == t.output);
         }
     }

--- a/src/rust-crypto/ripemd160.rs
+++ b/src/rust-crypto/ripemd160.rs
@@ -146,7 +146,7 @@ macro_rules! process_block(
 
 fn process_msg_block(data: &[u8], h: &mut [u32, ..DIGEST_BUF_LEN]) {
     let mut w = [0u32, ..WORK_BUF_LEN];
-    read_u32v_le(w[mut 0..16], data);
+    read_u32v_le(w.slice_mut(0,16), data);
     process_block!(h, w[],
         // Round 1
         round1: h_ordering 0, 1, 2, 3, 4 data_index  0 roll_shift 11
@@ -391,11 +391,11 @@ impl Digest for Ripemd160 {
             self.computed = true;
         }
         
-        write_u32_le(out[mut 0..4], self.h[0]);
-        write_u32_le(out[mut 4..8], self.h[1]);
-        write_u32_le(out[mut 8..12], self.h[2]);
-        write_u32_le(out[mut 12..16], self.h[3]);
-        write_u32_le(out[mut 16..20], self.h[4]);
+        write_u32_le(out.slice_mut(0,4), self.h[0]);
+        write_u32_le(out.slice_mut(4,8), self.h[1]);
+        write_u32_le(out.slice_mut(8,12), self.h[2]);
+        write_u32_le(out.slice_mut(12,16), self.h[3]);
+        write_u32_le(out.slice_mut(16,20), self.h[4]);
     }
 
     /**

--- a/src/rust-crypto/salsa20.rs
+++ b/src/rust-crypto/salsa20.rs
@@ -86,11 +86,11 @@ impl Salsa20 {
         xsalsa20.hsalsa20_hash();
 
         let mut new_key = [0, ..32];
-        copy_memory(new_key[mut 0..4], xsalsa20.output[0..4]);
-        copy_memory(new_key[mut 4..8], xsalsa20.output[20..24]);
-        copy_memory(new_key[mut 8..12], xsalsa20.output[40..44]);
-        copy_memory(new_key[mut 12..16], xsalsa20.output[60..64]);
-        copy_memory(new_key[mut 16..32], xsalsa20.output[24..40]);
+        copy_memory(new_key.slice_mut(0,4), xsalsa20.output[0..4]);
+        copy_memory(new_key.slice_mut(4,8), xsalsa20.output[20..24]);
+        copy_memory(new_key.slice_mut(8,12), xsalsa20.output[40..44]);
+        copy_memory(new_key.slice_mut(12,16), xsalsa20.output[60..64]);
+        copy_memory(new_key.slice_mut(16,32), xsalsa20.output[24..40]);
 
         xsalsa20.expand32(&new_key, nonce[16..24]);
 
@@ -98,48 +98,48 @@ impl Salsa20 {
     }
 
     fn expand16(&mut self, key: &[u8], nonce: &[u8]) {
-        copy_memory(self.state[mut 0..4], &[101u8, 120, 112, 97]);
-        copy_memory(self.state[mut 4..20], key);
-        copy_memory(self.state[mut 20..24], &[110u8, 100, 32, 49]);
-        copy_memory(self.state[mut 24..32], nonce);
-        copy_memory(self.state[mut 40..44], &[54u8, 45, 98, 121]);
-        copy_memory(self.state[mut 44..60], key);
-        copy_memory(self.state[mut 60..64], &[116u8, 101, 32, 107]);
+        copy_memory(self.state.slice_mut(0,4), &[101u8, 120, 112, 97]);
+        copy_memory(self.state.slice_mut(4,20), key);
+        copy_memory(self.state.slice_mut(20,24), &[110u8, 100, 32, 49]);
+        copy_memory(self.state.slice_mut(24,32), nonce);
+        copy_memory(self.state.slice_mut(40,44), &[54u8, 45, 98, 121]);
+        copy_memory(self.state.slice_mut(44,60), key);
+        copy_memory(self.state.slice_mut(60,64), &[116u8, 101, 32, 107]);
     }
 
     fn expand32(&mut self, key: &[u8], nonce: &[u8]) {
-        copy_memory(self.state[mut 0..4], &[101u8, 120, 112, 97]);
-        copy_memory(self.state[mut 4..20], key[0..16]);
-        copy_memory(self.state[mut 20..24], &[110u8, 100, 32, 51]);
-        copy_memory(self.state[mut 24..32], nonce);
-        copy_memory(self.state[mut 40..44], &[50u8, 45, 98, 121]);
-        copy_memory(self.state[mut 44..60], key[16..32]);
-        copy_memory(self.state[mut 60..64], &[116u8, 101, 32, 107]);
+        copy_memory(self.state.slice_mut(0,4), &[101u8, 120, 112, 97]);
+        copy_memory(self.state.slice_mut(4,20), key[0..16]);
+        copy_memory(self.state.slice_mut(20,24), &[110u8, 100, 32, 51]);
+        copy_memory(self.state.slice_mut(24,32), nonce);
+        copy_memory(self.state.slice_mut(40,44), &[50u8, 45, 98, 121]);
+        copy_memory(self.state.slice_mut(44,60), key[16..32]);
+        copy_memory(self.state.slice_mut(60,64), &[116u8, 101, 32, 107]);
     }
 
     fn hsalsa20_expand(&mut self, key: &[u8], nonce: &[u8]) {
-        copy_memory(self.state[mut 0..4], &[101u8, 120, 112, 97]);
-        copy_memory(self.state[mut 4..20], key[0..16]);
-        copy_memory(self.state[mut 20..24], &[110u8, 100, 32, 51]);
-        copy_memory(self.state[mut 24..40], nonce);
-        copy_memory(self.state[mut 40..44], &[50u8, 45, 98, 121]);
-        copy_memory(self.state[mut 44..60], key[16..32]);
-        copy_memory(self.state[mut 60..64], &[116u8, 101, 32, 107]);
+        copy_memory(self.state.slice_mut(0,4), &[101u8, 120, 112, 97]);
+        copy_memory(self.state.slice_mut(4,20), key[0..16]);
+        copy_memory(self.state.slice_mut(20,24), &[110u8, 100, 32, 51]);
+        copy_memory(self.state.slice_mut(24,40), nonce);
+        copy_memory(self.state.slice_mut(40,44), &[50u8, 45, 98, 121]);
+        copy_memory(self.state.slice_mut(44,60), key[16..32]);
+        copy_memory(self.state.slice_mut(60,64), &[116u8, 101, 32, 107]);
     }
 
     fn hash(&mut self) {
-        write_u32_le(self.state[mut 32..36], self.counter as u32);
-        write_u32_le(self.state[mut 36..40], (self.counter >> 32) as u32);
+        write_u32_le(self.state.slice_mut(32,36), self.counter as u32);
+        write_u32_le(self.state.slice_mut(36,40), (self.counter >> 32) as u32);
         
         let mut x = [0u32, ..16];
         let mut z = [0u32, ..16];
-        read_u32v_le(x[mut], &self.state);
-        read_u32v_le(z[mut], &self.state);
+        read_u32v_le(x.as_mut_slice(), &self.state);
+        read_u32v_le(z.as_mut_slice(), &self.state);
         for _ in range(0u, 10) {
             doubleround(&mut z);
         }
         for i in range(0u, 16) {
-            write_u32_le(self.output[mut i*4..(i+1)*4], x[i] + z[i]);
+            write_u32_le(self.output.slice_mut(i*4,(i+1)*4), x[i] + z[i]);
         }
         
         self.counter += 1;
@@ -148,12 +148,12 @@ impl Salsa20 {
 
     fn hsalsa20_hash(&mut self) {
         let mut x = [0u32, ..16];
-        read_u32v_le(x[mut], &self.state);
+        read_u32v_le(x.as_mut_slice(), &self.state);
         for _ in range(0u, 10) {
             doubleround(&mut x);
         }
         for i in range(0u, 16) {
-            write_u32_le(self.output[mut i*4..(i+1)*4], x[i]);
+            write_u32_le(self.output.slice_mut(i*4,(i+1)*4), x[i]);
         }
     }
 

--- a/src/rust-crypto/sha1.rs
+++ b/src/rust-crypto/sha1.rs
@@ -64,7 +64,7 @@ fn process_msg_block(data: &[u8], h: &mut [u32, ..DIGEST_BUF_LEN]) {
     let mut w = [0u32, ..WORK_BUF_LEN];
 
     // Initialize the first 16 words of the vector w
-    read_u32v_be(w[mut 0..16], data);
+    read_u32v_be(w.slice_mut(0,16), data);
 
     // Initialize the rest of vector w
     t = 16u;
@@ -140,11 +140,11 @@ fn mk_result(st: &mut Sha1, rs: &mut [u8]) {
         st.computed = true;
     }
 
-    write_u32_be(rs[mut 0..4], st.h[0]);
-    write_u32_be(rs[mut 4..8], st.h[1]);
-    write_u32_be(rs[mut 8..12], st.h[2]);
-    write_u32_be(rs[mut 12..16], st.h[3]);
-    write_u32_be(rs[mut 16..20], st.h[4]);
+    write_u32_be(rs.slice_mut(0,4), st.h[0]);
+    write_u32_be(rs.slice_mut(4,8), st.h[1]);
+    write_u32_be(rs.slice_mut(8,12), st.h[2]);
+    write_u32_be(rs.slice_mut(12,16), st.h[3]);
+    write_u32_be(rs.slice_mut(16,20), st.h[4]);
 }
 
 impl Sha1 {

--- a/src/rust-crypto/sha2.rs
+++ b/src/rust-crypto/sha2.rs
@@ -107,7 +107,7 @@ impl Engine512State {
         );
 
 
-        read_u64v_be(w[mut 0..16], data);
+        read_u64v_be(w.slice_mut(0,16), data);
 
         // Putting the message schedule inside the same loop as the round calculations allows for
         // the compiler to generate better code.
@@ -256,14 +256,14 @@ impl Digest for Sha512 {
     fn result(&mut self, out: &mut [u8]) {
         self.engine.finish();
 
-        write_u64_be(out[mut 0..8], self.engine.state.h0);
-        write_u64_be(out[mut 8..16], self.engine.state.h1);
-        write_u64_be(out[mut 16..24], self.engine.state.h2);
-        write_u64_be(out[mut 24..32], self.engine.state.h3);
-        write_u64_be(out[mut 32..40], self.engine.state.h4);
-        write_u64_be(out[mut 40..48], self.engine.state.h5);
-        write_u64_be(out[mut 48..56], self.engine.state.h6);
-        write_u64_be(out[mut 56..64], self.engine.state.h7);
+        write_u64_be(out.slice_mut(0,8), self.engine.state.h0);
+        write_u64_be(out.slice_mut(8,16), self.engine.state.h1);
+        write_u64_be(out.slice_mut(16,24), self.engine.state.h2);
+        write_u64_be(out.slice_mut(24,32), self.engine.state.h3);
+        write_u64_be(out.slice_mut(32,40), self.engine.state.h4);
+        write_u64_be(out.slice_mut(40,48), self.engine.state.h5);
+        write_u64_be(out.slice_mut(48,56), self.engine.state.h6);
+        write_u64_be(out.slice_mut(56,64), self.engine.state.h7);
     }
 
     fn reset(&mut self) {
@@ -311,12 +311,12 @@ impl Digest for Sha384 {
     fn result(&mut self, out: &mut [u8]) {
         self.engine.finish();
 
-        write_u64_be(out[mut 0..8], self.engine.state.h0);
-        write_u64_be(out[mut 8..16], self.engine.state.h1);
-        write_u64_be(out[mut 16..24], self.engine.state.h2);
-        write_u64_be(out[mut 24..32], self.engine.state.h3);
-        write_u64_be(out[mut 32..40], self.engine.state.h4);
-        write_u64_be(out[mut 40..48], self.engine.state.h5);
+        write_u64_be(out.slice_mut(0,8), self.engine.state.h0);
+        write_u64_be(out.slice_mut(8,16), self.engine.state.h1);
+        write_u64_be(out.slice_mut(16,24), self.engine.state.h2);
+        write_u64_be(out.slice_mut(24,32), self.engine.state.h3);
+        write_u64_be(out.slice_mut(32,40), self.engine.state.h4);
+        write_u64_be(out.slice_mut(40,48), self.engine.state.h5);
     }
 
     fn reset(&mut self) {
@@ -364,10 +364,10 @@ impl Digest for Sha512Trunc256 {
     fn result(&mut self, out: &mut [u8]) {
         self.engine.finish();
 
-        write_u64_be(out[mut 0..8], self.engine.state.h0);
-        write_u64_be(out[mut 8..16], self.engine.state.h1);
-        write_u64_be(out[mut 16..24], self.engine.state.h2);
-        write_u64_be(out[mut 24..32], self.engine.state.h3);
+        write_u64_be(out.slice_mut(0,8), self.engine.state.h0);
+        write_u64_be(out.slice_mut(8,16), self.engine.state.h1);
+        write_u64_be(out.slice_mut(16,24), self.engine.state.h2);
+        write_u64_be(out.slice_mut(24,32), self.engine.state.h3);
     }
 
     fn reset(&mut self) {
@@ -415,10 +415,10 @@ impl Digest for Sha512Trunc224 {
     fn result(&mut self, out: &mut [u8]) {
         self.engine.finish();
 
-        write_u64_be(out[mut 0..8], self.engine.state.h0);
-        write_u64_be(out[mut 8..16], self.engine.state.h1);
-        write_u64_be(out[mut 16..24], self.engine.state.h2);
-        write_u32_be(out[mut 24..28], (self.engine.state.h3 >> 32) as u32);
+        write_u64_be(out.slice_mut(0,8), self.engine.state.h0);
+        write_u64_be(out.slice_mut(8,16), self.engine.state.h1);
+        write_u64_be(out.slice_mut(16,24), self.engine.state.h2);
+        write_u32_be(out.slice_mut(24,28), (self.engine.state.h3 >> 32) as u32);
     }
 
     fn reset(&mut self) {
@@ -536,7 +536,7 @@ impl Engine256State {
         );
 
 
-        read_u32v_be(w[mut 0..16], data);
+        read_u32v_be(w.slice_mut(0,16), data);
 
         // Putting the message schedule inside the same loop as the round calculations allows for
         // the compiler to generate better code.
@@ -678,14 +678,14 @@ impl Digest for Sha256 {
     fn result(&mut self, out: &mut [u8]) {
         self.engine.finish();
 
-        write_u32_be(out[mut 0..4], self.engine.state.h0);
-        write_u32_be(out[mut 4..8], self.engine.state.h1);
-        write_u32_be(out[mut 8..12], self.engine.state.h2);
-        write_u32_be(out[mut 12..16], self.engine.state.h3);
-        write_u32_be(out[mut 16..20], self.engine.state.h4);
-        write_u32_be(out[mut 20..24], self.engine.state.h5);
-        write_u32_be(out[mut 24..28], self.engine.state.h6);
-        write_u32_be(out[mut 28..32], self.engine.state.h7);
+        write_u32_be(out.slice_mut(0,4), self.engine.state.h0);
+        write_u32_be(out.slice_mut(4,8), self.engine.state.h1);
+        write_u32_be(out.slice_mut(8,12), self.engine.state.h2);
+        write_u32_be(out.slice_mut(12,16), self.engine.state.h3);
+        write_u32_be(out.slice_mut(16,20), self.engine.state.h4);
+        write_u32_be(out.slice_mut(20,24), self.engine.state.h5);
+        write_u32_be(out.slice_mut(24,28), self.engine.state.h6);
+        write_u32_be(out.slice_mut(28,32), self.engine.state.h7);
     }
 
     fn reset(&mut self) {
@@ -733,13 +733,13 @@ impl Digest for Sha224 {
 
     fn result(&mut self, out: &mut [u8]) {
         self.engine.finish();
-        write_u32_be(out[mut 0..4], self.engine.state.h0);
-        write_u32_be(out[mut 4..8], self.engine.state.h1);
-        write_u32_be(out[mut 8..12], self.engine.state.h2);
-        write_u32_be(out[mut 12..16], self.engine.state.h3);
-        write_u32_be(out[mut 16..20], self.engine.state.h4);
-        write_u32_be(out[mut 20..24], self.engine.state.h5);
-        write_u32_be(out[mut 24..28], self.engine.state.h6);
+        write_u32_be(out.slice_mut(0,4), self.engine.state.h0);
+        write_u32_be(out.slice_mut(4,8), self.engine.state.h1);
+        write_u32_be(out.slice_mut(8,12), self.engine.state.h2);
+        write_u32_be(out.slice_mut(12,16), self.engine.state.h3);
+        write_u32_be(out.slice_mut(16,20), self.engine.state.h4);
+        write_u32_be(out.slice_mut(20,24), self.engine.state.h5);
+        write_u32_be(out.slice_mut(24,28), self.engine.state.h6);
     }
 
     fn reset(&mut self) {


### PR DESCRIPTION
This fixes up 100+ errors on the latest rust nightly!

See rust-lang/rust commits:
- rust-lang/rust@3bf40568
- rust-lang/rust@4e2afb00

Which require using the slicing methods in certain instances where
mutability of a slice cannot be "inferred."

I applied this fix using regular expressions; so there are likely instances where `rustc` _could've infer mutability_ for the experimental slicing syntax.

---

So... **this** must be why the new slicing syntax is behind a feature flag.
