### PR TITLE
rename unsafe_mut to get_unchecked_mut - fixes #196

### DIFF
--- a/src/rust-crypto/aesni.rs
+++ b/src/rust-crypto/aesni.rs
@@ -96,7 +96,7 @@ unsafe fn aesimc(round_keys: *mut u8) {
 #[allow(unused_assignments)]
 fn setup_working_key_aesni_128(key: &[u8], key_type: KeyType, round_key: &mut [u8]) {
     unsafe {
-        let mut round_keysp: *mut u8 = round_key.unsafe_mut(0);
+        let mut round_keysp: *mut u8 = round_key.get_unchecked_mut(0);
         let keyp: *const u8 = key.unsafe_get(0);
 
         asm!(
@@ -153,7 +153,7 @@ fn setup_working_key_aesni_128(key: &[u8], key_type: KeyType, round_key: &mut [u
             KeyType::Decryption => {
                 // range of rounds keys from #1 to #9; skip the first and last key
                 for i in range(1u, 10) {
-                    aesimc(round_key.unsafe_mut(16 * i));
+                    aesimc(round_key.get_unchecked_mut(16 * i));
                 }
             }
             KeyType::Encryption => { /* nothing more to do */ }
@@ -164,7 +164,7 @@ fn setup_working_key_aesni_128(key: &[u8], key_type: KeyType, round_key: &mut [u
 #[allow(unused_assignments)]
 fn setup_working_key_aesni_192(key: &[u8], key_type: KeyType, round_key: &mut [u8]) {
     unsafe {
-        let mut round_keysp: *mut u8 = round_key.unsafe_mut(0);
+        let mut round_keysp: *mut u8 = round_key.get_unchecked_mut(0);
         let keyp: *const u8 = key.unsafe_get(0);
 
         asm!(
@@ -256,7 +256,7 @@ fn setup_working_key_aesni_192(key: &[u8], key_type: KeyType, round_key: &mut [u
             KeyType::Decryption => {
                 // range of rounds keys from #1 to #11; skip the first and last key
                 for i in range(1u, 12) {
-                    aesimc(round_key.unsafe_mut(16 * i));
+                    aesimc(round_key.get_unchecked_mut(16 * i));
                 }
             }
             KeyType::Encryption => { /* nothing more to do */ }
@@ -267,7 +267,7 @@ fn setup_working_key_aesni_192(key: &[u8], key_type: KeyType, round_key: &mut [u
 #[allow(unused_assignments)]
 fn setup_working_key_aesni_256(key: &[u8], key_type: KeyType, round_key: &mut [u8]) {
     unsafe {
-        let mut round_keysp: *mut u8 = round_key.unsafe_mut(0);
+        let mut round_keysp: *mut u8 = round_key.get_unchecked_mut(0);
         let keyp: *const u8 = key.unsafe_get(0);
 
         asm!(
@@ -367,7 +367,7 @@ fn setup_working_key_aesni_256(key: &[u8], key_type: KeyType, round_key: &mut [u
             KeyType::Decryption => {
                 // range of rounds keys from #1 to #13; skip the first and last key
                 for i in range(1u, 14) {
-                    aesimc(round_key.unsafe_mut(16 * i));
+                    aesimc(round_key.get_unchecked_mut(16 * i));
                 }
             }
             KeyType::Encryption => { /* nothing more to do */ }
@@ -380,7 +380,7 @@ fn encrypt_block_aesni(rounds: uint, input: &[u8], round_keys: &[u8], output: &m
     unsafe {
         let mut rounds = rounds;
         let mut round_keysp: *const u8 = round_keys.unsafe_get(0);
-        let outp: *mut u8 = output.unsafe_mut(0);
+        let outp: *mut u8 = output.get_unchecked_mut(0);
         let inp: *const u8 = input.unsafe_get(0);
 
         asm!(
@@ -422,7 +422,7 @@ fn decrypt_block_aesni(rounds: uint, input: &[u8], round_keys: &[u8], output: &m
     unsafe {
         let mut rounds = rounds;
         let mut round_keysp: *const u8 = round_keys.unsafe_get(round_keys.len() - 16);
-        let outp: *mut u8 = output.unsafe_mut(0);
+        let outp: *mut u8 = output.get_unchecked_mut(0);
         let inp: *const u8 = input.unsafe_get(0);
 
         asm!(

--- a/src/rust-crypto/cryptoutil.rs
+++ b/src/rust-crypto/cryptoutil.rs
@@ -25,7 +25,7 @@ pub fn write_u64_be(dst: &mut[u8], mut input: u64) {
     input = input.to_be();
     unsafe {
         let tmp = &input as *const _ as *const u8;
-        ptr::copy_nonoverlapping_memory(dst.unsafe_mut(0), tmp, 8);
+        ptr::copy_nonoverlapping_memory(dst.get_unchecked_mut(0), tmp, 8);
     }
 }
 
@@ -33,7 +33,7 @@ pub fn write_u64_be(dst: &mut[u8], mut input: u64) {
 pub fn write_u64v_le(dst: &mut[u8], input: &[u64]) {
     assert!(dst.len() == 8 * input.len());
     unsafe {
-        let mut x: *mut u8 = dst.unsafe_mut(0);
+        let mut x: *mut u8 = dst.get_unchecked_mut(0);
         let mut y: *const u64 = input.unsafe_get(0);
         for _ in range(0, input.len()) {
             let tmp = (*y).to_le();
@@ -51,7 +51,7 @@ pub fn write_u32_be(dst: &mut [u8], mut input: u32) {
     input = input.to_be();
     unsafe {
         let tmp = &input as *const _ as *const u8;
-        ptr::copy_nonoverlapping_memory(dst.unsafe_mut(0), tmp, 4);
+        ptr::copy_nonoverlapping_memory(dst.get_unchecked_mut(0), tmp, 4);
     }
 }
 
@@ -62,7 +62,7 @@ pub fn write_u32_le(dst: &mut[u8], mut input: u32) {
     input = input.to_le();
     unsafe {
         let tmp = &input as *const _ as *const u8;
-        ptr::copy_nonoverlapping_memory(dst.unsafe_mut(0), tmp, 4);
+        ptr::copy_nonoverlapping_memory(dst.get_unchecked_mut(0), tmp, 4);
     }
 }
 
@@ -70,7 +70,7 @@ pub fn write_u32_le(dst: &mut[u8], mut input: u32) {
 pub fn read_u64v_be(dst: &mut[u64], input: &[u8]) {
     assert!(dst.len() * 8 == input.len());
     unsafe {
-        let mut x = dst.unsafe_mut(0) as *mut u64;
+        let mut x = dst.get_unchecked_mut(0) as *mut u64;
         let mut y = input.unsafe_get(0) as *const u8;
         for _ in range(0, dst.len()) {
             let mut tmp: u64 = mem::uninitialized();
@@ -86,7 +86,7 @@ pub fn read_u64v_be(dst: &mut[u64], input: &[u8]) {
 pub fn read_u64v_le(dst: &mut[u64], input: &[u8]) {
     assert!(dst.len() * 8 == input.len());
     unsafe {
-        let mut x = dst.unsafe_mut(0) as *mut u64;
+        let mut x = dst.get_unchecked_mut(0) as *mut u64;
         let mut y = input.unsafe_get(0) as *const u8;
         for _ in range(0, dst.len()) {
             let mut tmp: u64 = mem::uninitialized();
@@ -102,7 +102,7 @@ pub fn read_u64v_le(dst: &mut[u64], input: &[u8]) {
 pub fn read_u32v_be(dst: &mut[u32], input: &[u8]) {
     assert!(dst.len() * 4 == input.len());
     unsafe {
-        let mut x = dst.unsafe_mut(0) as *mut u32;
+        let mut x = dst.get_unchecked_mut(0) as *mut u32;
         let mut y = input.unsafe_get(0) as *const u8;
         for _ in range(0, dst.len()) {
             let mut tmp: u32 = mem::uninitialized();
@@ -118,7 +118,7 @@ pub fn read_u32v_be(dst: &mut[u32], input: &[u8]) {
 pub fn read_u32v_le(dst: &mut[u32], input: &[u8]) {
     assert!(dst.len() * 4 == input.len());
     unsafe {
-        let mut x = dst.unsafe_mut(0) as *mut u32;
+        let mut x = dst.get_unchecked_mut(0) as *mut u32;
         let mut y = input.unsafe_get(0) as *const u8;
         for _ in range(0, dst.len()) {
             let mut tmp: u32 = mem::uninitialized();


### PR DESCRIPTION
`cargo test` gives with these changes.

test result: ok. 78 passed; 0 failed; 49 ignored; 0 measured

Please see also:

http://doc.rust-lang.org/std/primitive.slice.html#method.get_unchecked_mut


