### PR TITLE
Fix breakage caused by the changes to closures in rust nightly

### DIFF
--- a/src/rust-crypto/blockmodes.rs
+++ b/src/rust-crypto/blockmodes.rs
@@ -1026,10 +1026,10 @@ mod test {
     fn run_inc(
             input: &[u8],
             output: &mut [u8],
-            op: |&mut RefReadBuffer, &mut RefWriteBuffer, bool|
-                -> Result<BufferResult, SymmetricCipherError>,
-            next_in_len: || -> uint,
-            next_out_len: || -> uint,
+            mut op: &mut FnMut(&mut RefReadBuffer, &mut RefWriteBuffer, bool)
+                  -> Result<BufferResult, SymmetricCipherError>,
+            next_in_len: &mut FnMut() -> uint,
+            next_out_len: &mut FnMut() -> uint,
             immediate_eof: bool) {
         use std::cell::Cell;
 
@@ -1041,7 +1041,7 @@ mod test {
         let mut out_pos = 0u;
         let eof = Cell::new(false);
 
-        let in_end = |in_pos: uint, primary: bool| {
+        let in_end = &mut |&mut: in_pos: uint, primary: bool| {
             if eof.get() {
                 return in_len;
             }
@@ -1052,7 +1052,7 @@ mod test {
             cmp::min(in_len, in_pos + cmp::max(x, if primary { 1 } else { 0 }))
         };
 
-        let out_end = |out_pos: uint| {
+        let out_end = &mut |&mut: out_pos: uint| {
             let x = next_out_len();
             cmp::min(out_len, out_pos + cmp::max(x, 1))
         };
@@ -1124,11 +1124,11 @@ mod test {
         run_inc(
             test.get_plain(),
             cipher_out.as_mut_slice(),
-            |in_buff: &mut RefReadBuffer, out_buff: &mut RefWriteBuffer, eof: bool| {
+            &mut |&mut: in_buff: &mut RefReadBuffer, out_buff: &mut RefWriteBuffer, eof: bool| {
                 enc.encrypt(in_buff, out_buff, eof)
             },
-            || { 0 },
-            || { 1 },
+            &mut |&: | { 0 },
+            &mut |&: | { 1 },
             false);
         assert!(test.get_cipher() == cipher_out[]);
 
@@ -1136,19 +1136,19 @@ mod test {
         run_inc(
             test.get_cipher(),
             plain_out.as_mut_slice(),
-            |in_buff: &mut RefReadBuffer, out_buff: &mut RefWriteBuffer, eof: bool| {
+            &mut |&mut: in_buff: &mut RefReadBuffer, out_buff: &mut RefWriteBuffer, eof: bool| {
                 dec.decrypt(in_buff, out_buff, eof)
             },
-            || { 0 },
-            || { 1 },
+            &mut |&: | { 0 },
+            &mut |&: | { 1 },
             false);
         assert!(test.get_plain() == plain_out[]);
     }
 
     fn run_rand_test<T: CipherTest, E: Encryptor, D: Decryptor>(
             test: &T,
-            new_enc: || -> E,
-            new_dec: || -> D) {
+            new_enc: &mut FnMut() -> E,
+            new_dec: &mut FnMut() -> D) {
         use std::rand;
         use std::rand::Rng;
 
@@ -1158,10 +1158,10 @@ mod test {
         let mut rng3: rand::StdRng = rand::SeedableRng::from_seed(tmp);
         let max_size = cmp::max(test.get_plain().len(), test.get_cipher().len());
 
-        let r1 = || {
+        let r1 = &mut |&mut: | {
             rng1.gen_range(0, max_size)
         };
-        let r2 = || {
+        let r2 = &mut |&mut: | {
             rng2.gen_range(0, max_size)
         };
 
@@ -1173,11 +1173,11 @@ mod test {
             run_inc(
                 test.get_plain(),
                 cipher_out.as_mut_slice(),
-                |in_buff: &mut RefReadBuffer, out_buff: &mut RefWriteBuffer, eof: bool| {
+                &mut |in_buff: &mut RefReadBuffer, out_buff: &mut RefWriteBuffer, eof: bool| {
                     enc.encrypt(in_buff, out_buff, eof)
                 },
-                || { r1() },
-                || { r2() },
+                &mut |&mut: | { r1() },
+                &mut |&mut: | { r2() },
                 rng3.gen());
             assert!(test.get_cipher() == cipher_out[]);
 
@@ -1185,11 +1185,11 @@ mod test {
             run_inc(
                 test.get_cipher(),
                 plain_out.as_mut_slice(),
-                |in_buff: &mut RefReadBuffer, out_buff: &mut RefWriteBuffer, eof: bool| {
+                &mut |&mut: in_buff: &mut RefReadBuffer, out_buff: &mut RefWriteBuffer, eof: bool| {
                     dec.decrypt(in_buff, out_buff, eof)
                 },
-                || { r1() },
-                || { r2() },
+                &mut |&mut: | { r1() },
+                &mut |&mut: | { r2() },
                 rng3.gen());
             assert!(test.get_plain() == plain_out[]);
         }
@@ -1197,8 +1197,8 @@ mod test {
 
     fn run_test<T: CipherTest, E: Encryptor, D: Decryptor>(
             test: &T,
-            new_enc: || -> E,
-            new_dec: || -> D) {
+            new_enc: &mut FnMut() -> E,
+            new_dec: &mut FnMut() -> D) {
         run_full_test(test, &mut new_enc(), &mut new_dec());
         run_inc1_test(test, &mut new_enc(), &mut new_dec());
         run_rand_test(test, new_enc, new_dec);
@@ -1210,11 +1210,11 @@ mod test {
         for test in tests.iter() {
             run_test(
                 test,
-                || {
+                &mut |&: | {
                     let aes_enc = aessafe::AesSafe128Encryptor::new(test.key[]);
                     EcbEncryptor::new(aes_enc, NoPadding)
                 },
-                || {
+                &mut |&: | {
                     let aes_dec = aessafe::AesSafe128Decryptor::new(test.key[]);
                     EcbDecryptor::new(aes_dec, NoPadding)
                 });
@@ -1227,11 +1227,11 @@ mod test {
         for test in tests.iter() {
             run_test(
                 test,
-                || {
+                &mut |&: | {
                     let aes_enc = aessafe::AesSafe128Encryptor::new(test.key[]);
                     EcbEncryptor::new(aes_enc, PkcsPadding)
                 },
-                || {
+                &mut |&: | {
                     let aes_dec = aessafe::AesSafe128Decryptor::new(test.key[]);
                     EcbDecryptor::new(aes_dec, PkcsPadding)
                 });
@@ -1244,11 +1244,11 @@ mod test {
         for test in tests.iter() {
             run_test(
                 test,
-                || {
+                &mut |&: | {
                     let aes_enc = aessafe::AesSafe128Encryptor::new(test.key[]);
                     CbcEncryptor::new(aes_enc, NoPadding, test.iv.clone())
                 },
-                || {
+                &mut |&: | {
                     let aes_dec = aessafe::AesSafe128Decryptor::new(test.key[]);
                     CbcDecryptor::new(aes_dec, NoPadding, test.iv.clone())
                 });
@@ -1261,11 +1261,11 @@ mod test {
         for test in tests.iter() {
             run_test(
                 test,
-                || {
+                &mut |&: | {
                     let aes_enc = aessafe::AesSafe128Encryptor::new(test.key[]);
                     CbcEncryptor::new(aes_enc, PkcsPadding, test.iv.clone())
                 },
-                || {
+                &mut |&: | {
                     let aes_dec = aessafe::AesSafe128Decryptor::new(test.key[]);
                     CbcDecryptor::new(aes_dec, PkcsPadding, test.iv.clone())
                 });
@@ -1278,11 +1278,11 @@ mod test {
         for test in tests.iter() {
             run_test(
                 test,
-                || {
+                &mut |&: | {
                     let aes_enc = aessafe::AesSafe128Encryptor::new(test.key[]);
                     CtrMode::new(aes_enc, test.ctr.clone())
                 },
-                || {
+                &mut |&: | {
                     let aes_enc = aessafe::AesSafe128Encryptor::new(test.key[]);
                     CtrMode::new(aes_enc, test.ctr.clone())
                 });
@@ -1295,11 +1295,11 @@ mod test {
         for test in tests.iter() {
             run_test(
                 test,
-                || {
+                &mut |&: | {
                     let aes_enc = aessafe::AesSafe128EncryptorX8::new(test.key[]);
                     CtrModeX8::new(aes_enc, test.ctr[])
                 },
-                || {
+                &mut |&: | {
                     let aes_enc = aessafe::AesSafe128EncryptorX8::new(test.key[]);
                     CtrModeX8::new(aes_enc, test.ctr[])
                 });

--- a/src/rust-crypto/cryptoutil.rs
+++ b/src/rust-crypto/cryptoutil.rs
@@ -249,7 +249,7 @@ pub fn add_bytes_to_bits_tuple
 pub trait FixedBuffer {
     /// Input a vector of bytes. If the buffer becomes full, process it with the provided
     /// function and then clear the buffer.
-    fn input(&mut self, input: &[u8], func: |&[u8]|);
+    fn input(&mut self, input: &[u8], func: &mut FnMut(&[u8]));
 
     /// Reset the buffer.
     fn reset(&mut self);
@@ -280,7 +280,7 @@ pub trait FixedBuffer {
 
 macro_rules! impl_fixed_buffer( ($name:ident, $size:expr) => (
     impl FixedBuffer for $name {
-        fn input(&mut self, input: &[u8], func: |&[u8]|) {
+        fn input(&mut self, input: &[u8], func: &mut FnMut(&[u8])) {
             let mut i = 0;
 
             // FIXME: #6304 - This local variable shouldn't be necessary.
@@ -403,11 +403,11 @@ pub trait StandardPadding {
     /// and is guaranteed to have exactly rem remaining bytes when it returns. If there are not at
     /// least rem bytes available, the buffer will be zero padded, processed, cleared, and then
     /// filled with zeros again until only rem bytes are remaining.
-    fn standard_padding(&mut self, rem: uint, func: |&[u8]|);
+    fn standard_padding(&mut self, rem: uint, func: &mut FnMut(&[u8]));
 }
 
 impl <T: FixedBuffer> StandardPadding for T {
-    fn standard_padding(&mut self, rem: uint, func: |&[u8]|) {
+    fn standard_padding(&mut self, rem: uint, func: &mut FnMut(&[u8])) {
         let size = self.size();
 
         self.next(1)[0] = 128;

--- a/src/rust-crypto/md5.rs
+++ b/src/rust-crypto/md5.rs
@@ -179,7 +179,8 @@ impl Digest for Md5 {
         // 2^64 - ie: integer overflow is OK.
         self.length_bytes += input.len() as u64;
         let self_state = &mut self.state;
-        self.buffer.input(input, |d: &[u8]| { self_state.process_block(d); });
+        self.buffer.input(input, &mut |d: &[u8]| { self_state.process_block(d);}
+        );
     }
 
     fn reset(&mut self) {
@@ -192,7 +193,7 @@ impl Digest for Md5 {
     fn result(&mut self, out: &mut [u8]) {
         if !self.finished {
             let self_state = &mut self.state;
-            self.buffer.standard_padding(8, |d: &[u8]| { self_state.process_block(d); });
+            self.buffer.standard_padding(8, &mut |d: &[u8]| { self_state.process_block(d); });
             write_u32_le(self.buffer.next(4), (self.length_bytes << 3) as u32);
             write_u32_le(self.buffer.next(4), (self.length_bytes >> 29) as u32);
             self_state.process_block(self.buffer.full_buffer());

--- a/src/rust-crypto/ripemd160.rs
+++ b/src/rust-crypto/ripemd160.rs
@@ -371,7 +371,8 @@ impl Digest for Ripemd160 {
         // Assumes that msg.len() can be converted to u64 without overflow
         self.length_bits = add_bytes_to_bits(self.length_bits, msg.len() as u64);
         let st_h = &mut self.h;
-        self.buffer.input(msg, |d: &[u8]| {process_msg_block(d, &mut *st_h); });
+        self.buffer.input(msg, &mut |d: &[u8]| {process_msg_block(d, &mut *st_h);}
+        );
     }
     
     /**
@@ -382,7 +383,7 @@ impl Digest for Ripemd160 {
         
         if !self.computed {
             let st_h = &mut self.h;
-            self.buffer.standard_padding(8, |d: &[u8]| { process_msg_block(d, &mut *st_h) });
+            self.buffer.standard_padding(8, &mut |d: &[u8]| { process_msg_block(d, &mut *st_h) });
 
             write_u32_le(self.buffer.next(4), self.length_bits as u32);
             write_u32_le(self.buffer.next(4), (self.length_bits >> 32) as u32 );

--- a/src/rust-crypto/sha1.rs
+++ b/src/rust-crypto/sha1.rs
@@ -55,7 +55,7 @@ fn add_input(st: &mut Sha1, msg: &[u8]) {
     // Assumes that msg.len() can be converted to u64 without overflow
     st.length_bits = add_bytes_to_bits(st.length_bits, msg.len() as u64);
     let st_h = &mut st.h;
-    st.buffer.input(msg, |d: &[u8]| {process_msg_block(d, &mut *st_h); });
+    st.buffer.input(msg, &mut |d: &[u8]| {process_msg_block(d, &mut *st_h); });
 }
 
 fn process_msg_block(data: &[u8], h: &mut [u32; DIGEST_BUF_LEN]) {
@@ -132,7 +132,7 @@ fn circular_shift(bits: u32, word: u32) -> u32 {
 fn mk_result(st: &mut Sha1, rs: &mut [u8]) {
     if !st.computed {
         let st_h = &mut st.h;
-        st.buffer.standard_padding(8, |d: &[u8]| { process_msg_block(d, &mut *st_h) });
+        st.buffer.standard_padding(8, &mut |d: &[u8]| { process_msg_block(d, &mut *st_h) });
         write_u32_be(st.buffer.next(4), (st.length_bits >> 32) as u32 );
         write_u32_be(st.buffer.next(4), st.length_bits as u32);
         process_msg_block(st.buffer.full_buffer(), st_h);

--- a/src/rust-crypto/sha2.rs
+++ b/src/rust-crypto/sha2.rs
@@ -209,7 +209,7 @@ impl Engine512 {
         // Assumes that input.len() can be converted to u64 without overflow
         self.length_bits = add_bytes_to_bits_tuple(self.length_bits, input.len() as u64);
         let self_state = &mut self.state;
-        self.buffer.input(input, |input: &[u8]| { self_state.process_block(input) });
+        self.buffer.input(input, &mut |input: &[u8]| { self_state.process_block(input) });
     }
 
     fn finish(&mut self) {
@@ -218,7 +218,7 @@ impl Engine512 {
         }
 
         let self_state = &mut self.state;
-        self.buffer.standard_padding(16, |input: &[u8]| { self_state.process_block(input) });
+        self.buffer.standard_padding(16, &mut |input: &[u8]| { self_state.process_block(input) });
         match self.length_bits {
             (hi, low) => {
                 write_u64_be(self.buffer.next(8), hi);
@@ -634,7 +634,7 @@ impl Engine256 {
         // Assumes that input.len() can be converted to u64 without overflow
         self.length_bits = add_bytes_to_bits(self.length_bits, input.len() as u64);
         let self_state = &mut self.state;
-        self.buffer.input(input, |input: &[u8]| { self_state.process_block(input) });
+        self.buffer.input(input, &mut |input: &[u8]| { self_state.process_block(input) });
     }
 
     fn finish(&mut self) {
@@ -643,7 +643,7 @@ impl Engine256 {
         }
 
         let self_state = &mut self.state;
-        self.buffer.standard_padding(8, |input: &[u8]| { self_state.process_block(input) });
+        self.buffer.standard_padding(8, &mut |input: &[u8]| { self_state.process_block(input) });
         write_u32_be(self.buffer.next(4), (self.length_bits >> 32) as u32 );
         write_u32_be(self.buffer.next(4), self.length_bits as u32);
         self_state.process_block(self.buffer.full_buffer());


### PR DESCRIPTION
Note: This fixes all the syntax errors caused by the closure changes, and `cargo build` successfully builds the crate, but running `cargo test` causes rustc to die with an llvm error on both my machines.