### PR TITLE
Use unboxed closures everywhere

### DIFF
--- a/src/rust-crypto/cryptoutil.rs
+++ b/src/rust-crypto/cryptoutil.rs
@@ -249,7 +249,7 @@ pub fn add_bytes_to_bits_tuple
 pub trait FixedBuffer {
     /// Input a vector of bytes. If the buffer becomes full, process it with the provided
     /// function and then clear the buffer.
-    fn input(&mut self, input: &[u8], func: &mut FnMut(&[u8]));
+    fn input<F: FnMut(&[u8])>(&mut self, input: &[u8], func: F);
 
     /// Reset the buffer.
     fn reset(&mut self);
@@ -280,7 +280,7 @@ pub trait FixedBuffer {
 
 macro_rules! impl_fixed_buffer( ($name:ident, $size:expr) => (
     impl FixedBuffer for $name {
-        fn input(&mut self, input: &[u8], func: &mut FnMut(&[u8])) {
+        fn input<F: FnMut(&[u8])>(&mut self, input: &[u8], mut func: F) {
             let mut i = 0;
 
             // FIXME: #6304 - This local variable shouldn't be necessary.
@@ -403,11 +403,11 @@ pub trait StandardPadding {
     /// and is guaranteed to have exactly rem remaining bytes when it returns. If there are not at
     /// least rem bytes available, the buffer will be zero padded, processed, cleared, and then
     /// filled with zeros again until only rem bytes are remaining.
-    fn standard_padding(&mut self, rem: uint, func: &mut FnMut(&[u8]));
+    fn standard_padding<F: FnMut(&[u8])>(&mut self, rem: uint, func: F);
 }
 
 impl <T: FixedBuffer> StandardPadding for T {
-    fn standard_padding(&mut self, rem: uint, func: &mut FnMut(&[u8])) {
+    fn standard_padding<F: FnMut(&[u8])>(&mut self, rem: uint, mut func: F) {
         let size = self.size();
 
         self.next(1)[0] = 128;

--- a/src/rust-crypto/md5.rs
+++ b/src/rust-crypto/md5.rs
@@ -179,7 +179,7 @@ impl Digest for Md5 {
         // 2^64 - ie: integer overflow is OK.
         self.length_bytes += input.len() as u64;
         let self_state = &mut self.state;
-        self.buffer.input(input, &mut |d: &[u8]| { self_state.process_block(d);}
+        self.buffer.input(input, |d: &[u8]| { self_state.process_block(d);}
         );
     }
 
@@ -193,7 +193,7 @@ impl Digest for Md5 {
     fn result(&mut self, out: &mut [u8]) {
         if !self.finished {
             let self_state = &mut self.state;
-            self.buffer.standard_padding(8, &mut |d: &[u8]| { self_state.process_block(d); });
+            self.buffer.standard_padding(8, |d: &[u8]| { self_state.process_block(d); });
             write_u32_le(self.buffer.next(4), (self.length_bytes << 3) as u32);
             write_u32_le(self.buffer.next(4), (self.length_bytes >> 29) as u32);
             self_state.process_block(self.buffer.full_buffer());

--- a/src/rust-crypto/ripemd160.rs
+++ b/src/rust-crypto/ripemd160.rs
@@ -371,7 +371,7 @@ impl Digest for Ripemd160 {
         // Assumes that msg.len() can be converted to u64 without overflow
         self.length_bits = add_bytes_to_bits(self.length_bits, msg.len() as u64);
         let st_h = &mut self.h;
-        self.buffer.input(msg, &mut |d: &[u8]| {process_msg_block(d, &mut *st_h);}
+        self.buffer.input(msg, |d: &[u8]| {process_msg_block(d, &mut *st_h);}
         );
     }
     
@@ -383,7 +383,7 @@ impl Digest for Ripemd160 {
         
         if !self.computed {
             let st_h = &mut self.h;
-            self.buffer.standard_padding(8, &mut |d: &[u8]| { process_msg_block(d, &mut *st_h) });
+            self.buffer.standard_padding(8, |d: &[u8]| { process_msg_block(d, &mut *st_h) });
 
             write_u32_le(self.buffer.next(4), self.length_bits as u32);
             write_u32_le(self.buffer.next(4), (self.length_bits >> 32) as u32 );

--- a/src/rust-crypto/sha1.rs
+++ b/src/rust-crypto/sha1.rs
@@ -55,7 +55,7 @@ fn add_input(st: &mut Sha1, msg: &[u8]) {
     // Assumes that msg.len() can be converted to u64 without overflow
     st.length_bits = add_bytes_to_bits(st.length_bits, msg.len() as u64);
     let st_h = &mut st.h;
-    st.buffer.input(msg, &mut |d: &[u8]| {process_msg_block(d, &mut *st_h); });
+    st.buffer.input(msg, |d: &[u8]| {process_msg_block(d, &mut *st_h); });
 }
 
 fn process_msg_block(data: &[u8], h: &mut [u32; DIGEST_BUF_LEN]) {
@@ -132,7 +132,7 @@ fn circular_shift(bits: u32, word: u32) -> u32 {
 fn mk_result(st: &mut Sha1, rs: &mut [u8]) {
     if !st.computed {
         let st_h = &mut st.h;
-        st.buffer.standard_padding(8, &mut |d: &[u8]| { process_msg_block(d, &mut *st_h) });
+        st.buffer.standard_padding(8, |d: &[u8]| { process_msg_block(d, &mut *st_h) });
         write_u32_be(st.buffer.next(4), (st.length_bits >> 32) as u32 );
         write_u32_be(st.buffer.next(4), st.length_bits as u32);
         process_msg_block(st.buffer.full_buffer(), st_h);

--- a/src/rust-crypto/sha2.rs
+++ b/src/rust-crypto/sha2.rs
@@ -209,7 +209,7 @@ impl Engine512 {
         // Assumes that input.len() can be converted to u64 without overflow
         self.length_bits = add_bytes_to_bits_tuple(self.length_bits, input.len() as u64);
         let self_state = &mut self.state;
-        self.buffer.input(input, &mut |input: &[u8]| { self_state.process_block(input) });
+        self.buffer.input(input, |input: &[u8]| { self_state.process_block(input) });
     }
 
     fn finish(&mut self) {
@@ -218,7 +218,7 @@ impl Engine512 {
         }
 
         let self_state = &mut self.state;
-        self.buffer.standard_padding(16, &mut |input: &[u8]| { self_state.process_block(input) });
+        self.buffer.standard_padding(16, |input: &[u8]| { self_state.process_block(input) });
         match self.length_bits {
             (hi, low) => {
                 write_u64_be(self.buffer.next(8), hi);
@@ -634,7 +634,7 @@ impl Engine256 {
         // Assumes that input.len() can be converted to u64 without overflow
         self.length_bits = add_bytes_to_bits(self.length_bits, input.len() as u64);
         let self_state = &mut self.state;
-        self.buffer.input(input, &mut |input: &[u8]| { self_state.process_block(input) });
+        self.buffer.input(input, |input: &[u8]| { self_state.process_block(input) });
     }
 
     fn finish(&mut self) {
@@ -643,7 +643,7 @@ impl Engine256 {
         }
 
         let self_state = &mut self.state;
-        self.buffer.standard_padding(8, &mut |input: &[u8]| { self_state.process_block(input) });
+        self.buffer.standard_padding(8, |input: &[u8]| { self_state.process_block(input) });
         write_u32_be(self.buffer.next(4), (self.length_bits >> 32) as u32 );
         write_u32_be(self.buffer.next(4), self.length_bits as u32);
         self_state.process_block(self.buffer.full_buffer());


### PR DESCRIPTION
Use unboxed closures everywhere that closures are used. This basically just effects symmetric cipher blockmode tests and the digests. The digests seem to see a very minor performance improvement:

before:
```
test sha1::bench::sha1_10                         ... bench:        48 ns/iter (+/- 1) = 208 MB/s
test sha1::bench::sha1_1k                         ... bench:      3986 ns/iter (+/- 375) = 256 MB/s
test sha1::bench::sha1_64k                        ... bench:    253095 ns/iter (+/- 2086) = 258 MB/s
```

after:
```
test sha1::bench::sha1_10                         ... bench:        46 ns/iter (+/- 0) = 217 MB/s
test sha1::bench::sha1_1k                         ... bench:      3924 ns/iter (+/- 41) = 260 MB/s
test sha1::bench::sha1_64k                        ... bench:    250463 ns/iter (+/- 3073) = 261 MB/s
```