### PR TITLE
Salsa20 cleanups/performance optimizations.

### DIFF
--- a/src/salsa20.rs
+++ b/src/salsa20.rs
@@ -119,7 +119,7 @@ impl Salsa20 {
 
         let x8; let x9; // (x8, x9)
         if nonce.len() == 16 {
-            // HChaCha uses the full 16 byte nonce.
+            // HSalsa uses the full 16 byte nonce.
             x8 = read_u32_le(&nonce[8..12]);
             x9 = read_u32_le(&nonce[12..16]);
         } else {


### PR DESCRIPTION
The performance optimizations come mostly from processing a block at a time in the common case (same as my 'chacha20_perf' branch).

The cleanups aim to increase readability/maintainability of the code (storing the state as an array of 'u32's is more natural and how the papers are written), and also results in a fairly minor performance increase.

Before: salsa20::bench::salsa20_64k 403337 ns/iter (+/- 3252) = 162 MB/s
After: salsa20::bench::salsa20_64k 288177 ns/iter (+/- 1947) = 227 MB/s