### PR TITLE
Add cryptoutil::xor_keystream().

### DIFF
--- a/src/chacha20.rs
+++ b/src/chacha20.rs
@@ -8,7 +8,7 @@ use std::simd::u32x4;
 
 use buffer::{BufferResult, RefReadBuffer, RefWriteBuffer};
 use symmetriccipher::{Encryptor, Decryptor, SynchronousStreamCipher, SymmetricCipherError};
-use cryptoutil::{read_u32_le, symm_enc_or_dec, write_u32_le};
+use cryptoutil::{read_u32_le, symm_enc_or_dec, write_u32_le, xor_keystream};
 
 #[derive(Copy)]
 struct ChaChaState {
@@ -251,10 +251,7 @@ impl SynchronousStreamCipher for ChaCha20 {
 
             // Process the min(available keystream, remaining input length).
             let count = cmp::min(64 - self.offset, len - i);
-            for j in range(0, count) {
-                // j-th byte of the keystream, starting from offset.
-                output[i + j] = input[i + j] ^ self.output[self.offset + j];
-            }
+            xor_keystream(&mut output[i..i+count], &input[i..i+count], &self.output[self.offset..]);
             i += count;
             self.offset += count;
         }

--- a/src/salsa20.rs
+++ b/src/salsa20.rs
@@ -6,7 +6,7 @@
 
 use buffer::{BufferResult, RefReadBuffer, RefWriteBuffer};
 use symmetriccipher::{Encryptor, Decryptor, SynchronousStreamCipher, SymmetricCipherError};
-use cryptoutil::{read_u32_le, symm_enc_or_dec, write_u32_le};
+use cryptoutil::{read_u32_le, symm_enc_or_dec, write_u32_le, xor_keystream};
 
 use std::cmp;
 use std::simd::u32x4;
@@ -222,10 +222,7 @@ impl SynchronousStreamCipher for Salsa20 {
 
             // Process the min(available keystream, remaining input length).
             let count = cmp::min(64 - self.offset, len - i);
-            for j in range(0, count) {
-                // j-th byte of the keystream, starting from offset.
-                output[i + j] = input[i + j] ^ self.output[self.offset + j];
-            }
+            xor_keystream(&mut output[i..i+count], &input[i..i+count], &self.output[self.offset..]);
             i += count;
             self.offset += count;
         }


### PR DESCRIPTION
The log mostly describes this.  I didn't change the block cipher code, though the CTRx8 implementation should get a decent boost out of something like this.  If you would rather have a 64 bit targeted version, I can do that too, though the gains aren't massive.

The new utility routine does exactly what it says on the tin, except
that it processes 4 bytes at a time (and then handles the remainder if
any).

Before: chacha20::bench::chacha20_64k ... bench: 249568 ns/iter (+/- 24243) = 262 MB/s
After: chacha20::bench::chacha20_64k ... bench: 200760 ns/iter (+/- 4004) = 326 MB/s

It's worth noting that this could be even faster depending on the
target hardware eg:
 * 64 bit -> Process 8 bytes at a time (~350 MiB/s).
 * 64 bit, allows unaligned memory access -> transmute() (~370 MiB/s).

But, ARM probably is a good enough reason to use a generic 32 bit
implementation.