### PR TITLE
Salsa20 fixes

### DIFF
--- a/src/salsa20.rs
+++ b/src/salsa20.rs
@@ -96,6 +96,13 @@ impl Salsa20 {
         xsalsa20
     }
 
+    pub fn hsalsa20(key: &[u8], nonce: &[u8], out: &mut [u8]) {
+        assert!(key.len() == 32);
+        assert!(nonce.len() == 16);
+        let mut hsalsa20 = Salsa20 { state: Salsa20::expand(key, nonce), output: [0; 64], offset: 64 };
+        hsalsa20.hsalsa20_hash(out);
+    }
+
     fn expand(key: &[u8], nonce: &[u8]) -> SalsaState {
         let constant = match key.len() {
             16 => b"expand 16-byte k",

--- a/src/salsa20.rs
+++ b/src/salsa20.rs
@@ -96,13 +96,6 @@ impl Salsa20 {
         xsalsa20
     }
 
-    pub fn hsalsa20(key: &[u8], nonce: &[u8], out: &mut [u8]) {
-        assert!(key.len() == 32);
-        assert!(nonce.len() == 16);
-        let mut hsalsa20 = Salsa20 { state: Salsa20::expand(key, nonce), output: [0; 64], offset: 64 };
-        hsalsa20.hsalsa20_hash(out);
-    }
-
     fn expand(key: &[u8], nonce: &[u8]) -> SalsaState {
         let constant = match key.len() {
             16 => b"expand 16-byte k",
@@ -248,6 +241,13 @@ impl Decryptor for Salsa20 {
             -> Result<BufferResult, SymmetricCipherError> {
         symm_enc_or_dec(self, input, output)
     }
+}
+
+pub fn hsalsa20(key: &[u8], nonce: &[u8], out: &mut [u8]) {
+    assert!(key.len() == 32);
+    assert!(nonce.len() == 16);
+    let mut h = Salsa20 { state: Salsa20::expand(key, nonce), output: [0; 64], offset: 64 };
+    h.hsalsa20_hash(out);
 }
 
 #[cfg(test)]

--- a/src/salsa20.rs
+++ b/src/salsa20.rs
@@ -26,11 +26,11 @@ pub struct Salsa20 {
     offset: usize,
 }
 
-static S7:u32x4 = u32x4(7, 7, 7, 7);
-static S9:u32x4 = u32x4(9, 9, 9, 9);
-static S13:u32x4 = u32x4(13, 13, 13, 13);
-static S18:u32x4 = u32x4(18, 18, 18, 18);
-static S32:u32x4 = u32x4(32, 32, 32, 32);
+const S7:u32x4 = u32x4(7, 7, 7, 7);
+const S9:u32x4 = u32x4(9, 9, 9, 9);
+const S13:u32x4 = u32x4(13, 13, 13, 13);
+const S18:u32x4 = u32x4(18, 18, 18, 18);
+const S32:u32x4 = u32x4(32, 32, 32, 32);
 
 macro_rules! prepare_rowround {
     ($a: expr, $b: expr, $c: expr) => {{


### PR DESCRIPTION
The salsa20 code breaks (SIGSEGV, illegal hardware instruction) when linked from another crate with the latest nightly, the first change fixes that.  Not sure why the unit tests pass, and code from another crate breaks, but this fixes it.  Sorry about that.

The 2nd change because one-shot HChaCha20 is needed for NaCl's box construct (I have the rust-crypto crate mostly done, but not checked in yet).