### PR TITLE
Ed25519-keypair based key exchange/agreement

### DIFF
--- a/src/curve25519.rs
+++ b/src/curve25519.rs
@@ -2117,7 +2117,7 @@ pub fn curve25519(n: &[u8], p: &[u8]) -> [u8; 32] {
 
     swap = 0;
     // pos starts at 254 and goes down to 0
-    for pos in (0us..255).rev() {
+    for pos in (0usize..255).rev() {
         b = (e[pos / 8] >> (pos & 7)) as i32;
         b &= 1;
         swap ^= b;

--- a/src/curve25519.rs
+++ b/src/curve25519.rs
@@ -12,7 +12,7 @@ Bounds on each t[i] vary depending on context.
 */
 
 #[derive(Copy)]
-pub struct Fe([i32; 10]);
+pub struct Fe(pub [i32; 10]);
 
 impl PartialEq for Fe {
     fn eq(&self, other: &Fe) -> bool {
@@ -943,7 +943,7 @@ impl Fe {
             h5 as i32, h6 as i32, h7 as i32, h8 as i32, h9 as i32])
     }
 
-    fn invert(&self) -> Fe {
+    pub fn invert(&self) -> Fe {
         let z1 = *self;
 
         /* qhasm: z2 = z1^2^1 */

--- a/src/ed25519.rs
+++ b/src/ed25519.rs
@@ -3,6 +3,7 @@ use sha2::{Sha512};
 use curve25519::{GeP2, GeP3, ge_scalarmult_base, sc_reduce, sc_muladd, curve25519, Fe};
 use util::{fixed_time_eq};
 use std::iter::range_step;
+use std::ops::{Add, Sub, Mul};
 
 pub fn keypair(seed: &[u8]) -> ([u8; 64], [u8; 32]) {
     let mut secret: [u8; 64] = {
@@ -125,7 +126,7 @@ pub fn exchange(public_key: &[u8], private_key: &[u8]) -> [u8; 32] {
     let ed_y = Fe::from_bytes(&public_key);
     let ed_z = Fe([1,0,0,0,0,0,0,0,0,0]);
     // Produce public key in Montgomery form.
-    let mont_x = edwards_to_montgomery_x(&ed_y, &ed_z);
+    let mont_x = edwards_to_montgomery_x(ed_y, ed_z);
     // Produce private key from seed component (bytes 0 to 32) 
     // of extended secret key (64 bytes).
     let mut hasher = Sha512::new();
@@ -133,9 +134,9 @@ pub fn exchange(public_key: &[u8], private_key: &[u8]) -> [u8; 32] {
     let mut hash: [u8; 64] = [0; 64];
     hasher.result(&mut hash);
 
-    let shared_mont_x : [u8; 32] = curve25519::curve25519(&hash, &mont_x); // priv., pub.
+    let shared_mont_x : [u8; 32] = curve25519(&hash, &mont_x.to_bytes()); // priv., pub.
     /* Normally need to clamp this produced private key (hash), 
-       but this is done by curve25519 function proior to processing. */
+       but this is done by curve25519 function prior to processing. */
     shared_mont_x
     // For NaCl compatibility, subsequent step required: HSalsa20 hashing.
 }
@@ -143,8 +144,8 @@ pub fn exchange(public_key: &[u8], private_key: &[u8]) -> [u8; 32] {
 fn edwards_to_montgomery_x(ed_y: Fe, ed_z: Fe) -> Fe {
     let temp_x = ed_z.add(ed_y);
     let temp_z = ed_z.sub(ed_y);
-    temp_z = temp_z.invert();
-    let mont_x = temp_x.mul(temp_z);
+    let temp_z_inv = temp_z.invert();
+    let mont_x = temp_x.mul(temp_z_inv);
     mont_x
 }
 


### PR DESCRIPTION
As may be known, key exchange and signing are only very slightly different operations on the same base curve. It is possible to convert Ed25519 keys to Curve25519 keys - but not vice versa (trivially, anyway), as far as I am aware. It is therefore possible to use a single keypair for both key exchange and signing, which cuts down on complexity. curve25519.rs is missing a keypair gen function (there is the curve25519_base function, but it lacks clamping), so this can stand in for that for the time being perhaps.