### PR TITLE
Add HC-128 cipher and fix a SOSEMANUK cipher test

### DIFF
--- a/src/cryptoutil.rs
+++ b/src/cryptoutil.rs
@@ -77,6 +77,21 @@ pub fn write_u32_le(dst: &mut[u8], mut input: u32) {
     }
 }
 
+/// Write a vector of u32s into a vector of bytes. The values are written in little-endian format.
+pub fn write_u32v_le (dst: &mut[u8], input: &[u32]) {
+    assert!(dst.len() == 4 * input.len());
+    unsafe {
+        let mut x: *mut u8 = dst.get_unchecked_mut(0);
+        let mut y: *const u32 = input.get_unchecked(0);
+        for _ in range(0, input.len()) {
+            let tmp = (*y).to_le();
+            ptr::copy_nonoverlapping_memory(x, &tmp as *const _ as *const u8, 4);
+            x = x.offset(4);
+            y = y.offset(1);
+        }
+    }
+}
+
 /// Read a vector of bytes into a vector of u64s. The values are read in big-endian format.
 pub fn read_u64v_be(dst: &mut[u64], input: &[u8]) {
     assert!(dst.len() * 8 == input.len());

--- a/src/hc128.rs
+++ b/src/hc128.rs
@@ -1,0 +1,313 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+ 
+ 
+use buffer::{BufferResult, RefReadBuffer, RefWriteBuffer};
+use symmetriccipher::{Encryptor, Decryptor, SynchronousStreamCipher, SymmetricCipherError};
+use cryptoutil::{read_u32_le, symm_enc_or_dec, write_u32_le, write_u32v_le};
+ 
+use std::num::Int;
+use std::slice::bytes::copy_memory;
+
+use std::ptr;
+use std::intrinsics::offset;
+
+
+#[derive(Copy)]
+struct Hc128 {
+    p: [u32; 512],
+    q: [u32; 512],
+    cnt: usize,
+    output: [u8; 4],
+    output_index: usize
+}
+ 
+impl Hc128 {
+    pub fn new(key: &[u8], nonce: &[u8]) -> Hc128 {
+        assert!(key.len() == 16);
+        assert!(nonce.len() == 16);
+        let mut hc128 = Hc128 { p: [0; 512], q: [0; 512], cnt: 0, output: [0; 4], output_index: 0 };
+        hc128.init(&key, &nonce);
+ 
+        hc128
+    }
+
+    fn init(&mut self, key : &[u8], nonce : &[u8]) {
+        self.cnt = 0;
+
+        let mut w : [u32; 1280] = [0; 1280];
+
+        for i in range(0, 16) {
+            w[i >> 2] |= ((key[i] as u32) << (8 * (i & 0x3)));
+        }
+        unsafe {
+            ptr::copy_nonoverlapping_memory(w.as_mut_ptr().offset(4), w.as_ptr(), 4);
+        }
+        // for (dest, src) in (&mut w[4..8]).iter_mut().zip(w.iter()) {
+        //     *dest = *src;
+        // }
+
+        for i in range(0, nonce.len() & 16) {
+            w[(i >> 2) + 8] |= ((nonce[i] as u32) << (8 * (i & 0x3)));
+        }
+        unsafe {
+            ptr::copy_nonoverlapping_memory(w.as_mut_ptr().offset(12), w.as_ptr().offset(8), 4);
+        }
+        // for (dest, src) in (&mut w[12..16]).iter_mut().zip(w[8..12].iter()) {
+        //     *dest = *src;
+        // }
+
+        for i in range(16, 1280) {
+            w[i] = (f2(w[i - 2]) + w[i - 7] + f1(w[i - 15]) + w[i - 16] + (i as u32)) as u32;
+        }
+
+        // Copy contents of w into p and q
+        unsafe {
+            ptr::copy_nonoverlapping_memory(self.p.as_mut_ptr(), w.as_ptr().offset(256), 512);
+            ptr::copy_nonoverlapping_memory(self.q.as_mut_ptr(), w.as_ptr().offset(768), 512);
+        }
+        
+        for i in range(0, 512) {
+            self.p[i] = self.step();
+        }
+        for i in range(0, 512) {
+            self.q[i] = self.step();
+        }  
+     
+        self.cnt = 0;
+    }
+ 
+    fn step(&mut self) -> u32 {
+        let j : usize = self.cnt & 0x1FF;
+
+        // Precompute resources
+        let dimJ3 : usize = (j - 3) & 0x1FF;
+        let dimJ10 : usize = (j - 10) & 0x1FF;
+        let dimJ511 : usize = (j - 511) & 0x1FF;
+        let dimJ12 : usize = (j - 12) & 0x1FF;
+
+        let mut ret : u32;
+
+        if (self.cnt < 512) {
+            self.p[j] += (self.p[dimJ3].rotate_right(10) ^ self.p[dimJ511].rotate_right(23)) + self.p[dimJ10].rotate_right(8);
+            ret = (self.q[(self.p[dimJ12] & 0xFF) as usize] + self.q[(((self.p[dimJ12] >> 16) & 0xFF) + 256) as usize]) ^ self.p[j];
+        } else {
+            self.q[j] += (self.q[dimJ3].rotate_left(10) ^ self.q[dimJ511].rotate_left(23)) + self.q[dimJ10].rotate_left(8);
+            ret = (self.p[(self.q[dimJ12] & 0xFF) as usize] + self.p[(((self.q[dimJ12] >> 16) & 0xFF) + 256) as usize]) ^ self.q[j];
+        }
+
+        self.cnt = (self.cnt + 1) & 0x3FF;    
+        ret
+    }
+ 
+    fn next(&mut self) -> u8 {
+        if self.output_index == 0 {
+            let step = self.step();
+            write_u32_le(&mut self.output, step);
+        }
+        let ret = self.output[self.output_index];
+        self.output_index = (self.output_index + 1) & 0x3;
+
+        ret
+    }
+}
+
+fn f1(x: u32) -> u32 {
+    let ret : u32 = x.rotate_right(7) ^ x.rotate_right(18) ^ (x >> 3);
+    ret
+}
+
+fn f2(x: u32) -> u32 {
+    let ret : u32 = x.rotate_right(17) ^ x.rotate_right(19) ^ (x >> 10);
+    ret
+}
+
+impl SynchronousStreamCipher for Hc128 {
+    fn process(&mut self, input: &[u8], output: &mut [u8]) {
+        assert!(input.len() == output.len());
+
+        for (inb, outb) in input.iter().zip(output.iter_mut()) {
+            *outb = *inb ^ self.next();
+        }
+
+        // if input.len() <= 4 {
+        //     // Process data bytewise
+        //     for (inb, outb) in input.iter().zip(output.iter_mut()) {
+        //         *outb = *inb ^ self.next();
+        //     }
+        // } else {
+        //     let mut data_index = 0 as usize;
+        //     let data_index_end = data_index + input.len();
+
+        //     /*  Process any unused keystream (self.buffer) 
+        //      *  remaining from previous operations */
+        //     while self.output_index > 0 && data_index < data_index_end {
+        //         output[data_index] = input[data_index] ^ self.next();
+        //         data_index += 1;
+        //     }
+
+        //     /*  Process input data blockwise until depleted, 
+        //      *  or remaining length less than block size 
+        //      *  (size of the keystream buffer, self.buffer : 4 bytes) */
+        //     while data_index + 4 <= data_index_end {
+        //         let data_index_inc = data_index + 4;
+
+        //         // Read input as le-u32
+        //         let input_u32 = read_u32_le(&input[data_index..data_index_inc]);
+        //         // XOR with keystream u32
+        //         let xored = input_u32 ^ self.step();
+        //         // Write output as le-u32
+        //         write_u32_le(&mut output[data_index..data_index_inc], xored);
+                
+        //         // // Write keystream buffer
+        //         // write_u32_le(&mut self.output, step());
+        //         // // XOR input with keystream, and write to output
+        //         // for i in range(data_index, data_index_inc) {
+        //         //     let ks_index = 4 - data_index_inc - i;
+        //         //     let xored = input[i] ^ self.output[ks_index];
+        //         //     output[i] = xored;
+        //         // }
+
+        //         data_index = data_index_inc;
+        //     }
+
+        //     /*  Process remaining data, if any 
+        //      *  (e.g. input length not divisible by 4) */
+        //     while data_index < data_index_end {
+        //         output[data_index] = input[data_index] ^ self.next();
+        //         data_index += 1;
+        //     }
+        // }
+    }
+}
+ 
+impl Encryptor for Hc128 {
+    fn encrypt(&mut self, input: &mut RefReadBuffer, output: &mut RefWriteBuffer, _: bool)
+            -> Result<BufferResult, SymmetricCipherError> {
+        symm_enc_or_dec(self, input, output)
+    }
+}
+ 
+impl Decryptor for Hc128 {
+    fn decrypt(&mut self, input: &mut RefReadBuffer, output: &mut RefWriteBuffer, _: bool)
+            -> Result<BufferResult, SymmetricCipherError> {
+        symm_enc_or_dec(self, input, output)
+    }
+}
+
+ 
+// #[cfg(test)]
+mod test {
+    use hc128::Hc128;
+    use symmetriccipher::SynchronousStreamCipher;
+    use serialize::hex::{FromHex, ToHex};
+
+    // Vectors from http://www.ecrypt.eu.org/stream/svn/viewcvs.cgi/ecrypt/trunk/submissions/hc-256/hc-128/verified.test-vectors?rev=210&view=markup
+
+    #[test]
+    fn test_hc128_ecrypt_set_2_vector_0() {
+        let key = "00000000000000000000000000000000".from_hex().unwrap();
+        let nonce = "00000000000000000000000000000000".from_hex().unwrap();
+
+        let input = [0u8; 64];
+        let expected_output_hex = "82001573A003FD3B7FD72FFB0EAF63AAC62F12DEB629DCA72785A66268EC758B1EDB36900560898178E0AD009ABF1F491330DC1C246E3D6CB264F6900271D59C";
+        let expected_output = expected_output_hex.from_hex().unwrap();
+
+        let mut output = [0u8; 64];
+ 
+        let mut hc128 = Hc128::new(key.as_slice(), nonce.as_slice());
+        hc128.process(&input, &mut output);
+        assert!(output.as_slice() == expected_output.as_slice());
+    }
+
+    #[test]
+    fn test_hc128_ecrypt_set_6_vector_1() {
+        let key = "0558ABFE51A4F74A9DF04396E93C8FE2".from_hex().unwrap();
+        let nonce = "167DE44BB21980E74EB51C83EA51B81F".from_hex().unwrap();
+
+        let input = [0u8; 64];
+        let expected_output_hex = "4F864BF3C96D0363B1903F0739189138F6ED2BC0AF583FEEA0CEA66BA7E06E63FB28BF8B3CA0031D24ABB511C57DD17BFC2861C32400072CB680DF2E58A5CECC";
+        let expected_output = expected_output_hex.from_hex().unwrap();
+
+        let mut output = [0u8; 64];
+ 
+        let mut hc128 = Hc128::new(key.as_slice(), nonce.as_slice());
+        hc128.process(&input, &mut output);
+        assert!(output.as_slice() == expected_output.as_slice());
+    }
+
+    #[test]
+    fn test_hc128_ecrypt_set_6_vector_2() {
+        let key = "0A5DB00356A9FC4FA2F5489BEE4194E7".from_hex().unwrap();
+        let nonce = "1F86ED54BB2289F057BE258CF35AC128".from_hex().unwrap();
+
+        let input = [0u8; 64];
+        let expected_output_hex = "82168AB0023B79AAF1E6B4D823855E14A7084378036A951B1CFEF35173875ED86CB66AB8410491A08582BE40080C3102193BA567F9E95D096C3CC60927DD7901";
+        let expected_output = expected_output_hex.from_hex().unwrap();
+
+        let mut output = [0u8; 64];
+ 
+        let mut hc128 = Hc128::new(key.as_slice(), nonce.as_slice());
+        hc128.process(&input, &mut output);
+        assert!(output.as_slice() == expected_output.as_slice());
+    }
+
+    #[test]
+    fn test_hc128_ecrypt_set_6_vector_3() {
+        let key = "0F62B5085BAE0154A7FA4DA0F34699EC".from_hex().unwrap();
+        let nonce = "288FF65DC42B92F960C72E95FC63CA31".from_hex().unwrap();
+
+        let input = [0u8; 64];
+        let expected_output_hex = "1CD8AEDDFE52E217E835D0B7E84E2922D04B1ADBCA53C4522B1AA604C42856A90AF83E2614BCE65C0AECABDD8975B55700D6A26D52FFF0888DA38F1DE20B77B7";
+        let expected_output = expected_output_hex.from_hex().unwrap();
+
+        let mut output = [0u8; 64];
+ 
+        let mut hc128 = Hc128::new(key.as_slice(), nonce.as_slice());
+        hc128.process(&input, &mut output);
+        assert!(output.as_slice() == expected_output.as_slice());
+    }
+}
+ 
+#[cfg(test)]
+mod bench {
+    use test::Bencher;
+    use symmetriccipher::SynchronousStreamCipher;
+    use hc128::Hc128;
+ 
+    #[bench]
+    pub fn hc128_10(bh: & mut Bencher) {
+        let mut hc128 = Hc128::new(&[0; 16], &[0; 16]);
+        let input = [1u8; 10];
+        let mut output = [0u8; 10];
+        bh.iter( || {
+            hc128.process(&input, &mut output);
+        });
+        bh.bytes = input.len() as u64;
+    }
+   
+    #[bench]
+    pub fn hc128_1k(bh: & mut Bencher) {
+        let mut hc128 = Hc128::new(&[0; 16], &[0; 16]);
+        let input = [1u8; 1024];
+        let mut output = [0u8; 1024];
+        bh.iter( || {
+            hc128.process(&input, &mut output);
+        });
+        bh.bytes = input.len() as u64;
+    }
+ 
+    #[bench]
+    pub fn hc128_64k(bh: & mut Bencher) {
+        let mut hc128 = Hc128::new(&[0; 16], &[0; 16]);
+        let input = [1u8; 65536];
+        let mut output = [0u8; 65536];
+        bh.iter( || {
+            hc128.process(&input, &mut output);
+        });
+        bh.bytes = input.len() as u64;
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@ pub mod digest;
 pub mod ed25519;
 pub mod fortuna;
 pub mod ghash;
+pub mod hc128;
 pub mod hmac;
 pub mod hkdf;
 pub mod mac;

--- a/src/scrypt.rs
+++ b/src/scrypt.rs
@@ -16,7 +16,6 @@ use std::iter::repeat;
 use std::old_io::IoResult;
 use std::num::{Int, ToPrimitive};
 use std::mem::size_of;
-use std::simd::u32x4;
 
 use rand::{OsRng, Rng};
 use serialize::base64;
@@ -28,115 +27,6 @@ use pbkdf2::pbkdf2;
 use sha2::Sha256;
 use util::fixed_time_eq;
 
-#[derive(Copy)]
-struct SalsaState {
-  a: u32x4,
-  b: u32x4,
-  c: u32x4,
-  d: u32x4
-}
-
-static S7:u32x4 = u32x4(7, 7, 7, 7);
-static S9:u32x4 = u32x4(9, 9, 9, 9);
-static S13:u32x4 = u32x4(13, 13, 13, 13);
-static S18:u32x4 = u32x4(18, 18, 18, 18);
-static S32:u32x4 = u32x4(32, 32, 32, 32);
-
-macro_rules! prepare_rowround {
-    ($a: expr, $b: expr, $c: expr) => {{
-        let u32x4(a10, a11, a12, a13) = $a;
-        $a = u32x4(a13, a10, a11, a12);
-        let u32x4(b10, b11, b12, b13) = $b;
-        $b = u32x4(b12, b13, b10, b11);
-        let u32x4(c10, c11, c12, c13) = $c;
-        $c = u32x4(c11, c12, c13, c10);
-    }}
-}
-
-macro_rules! prepare_columnround {
-    ($a: expr, $b: expr, $c: expr) => {{
-        let u32x4(a13, a10, a11, a12) = $a;
-        $a = u32x4(a10, a11, a12, a13);
-        let u32x4(b12, b13, b10, b11) = $b;
-        $b = u32x4(b10, b11, b12, b13);
-        let u32x4(c11, c12, c13, c10) = $c;
-        $c = u32x4(c10, c11, c12, c13);
-    }}
-}
-
-macro_rules! add_rotate_xor {
-    ($dst: expr, $a: expr, $b: expr, $shift: expr) => {{
-        let v = $a + $b;
-        let r = S32 - $shift;
-        let right = v >> r;
-        $dst ^= (v << $shift) ^ right
-    }}
-}
-
-fn columnround(state: &mut SalsaState) -> () {
-    add_rotate_xor!(state.a, state.d, state.c, S7);
-    add_rotate_xor!(state.b, state.a, state.d, S9);
-    add_rotate_xor!(state.c, state.b, state.a, S13);
-    add_rotate_xor!(state.d, state.c, state.b, S18);
-}
-
-fn rowround(state: &mut SalsaState) -> () {
-    add_rotate_xor!(state.c, state.d, state.a, S7);
-    add_rotate_xor!(state.b, state.c, state.d, S9);
-    add_rotate_xor!(state.a, state.c, state.b, S13);
-    add_rotate_xor!(state.d, state.a, state.b, S18);
-}
-
-fn salsa20_8_simd(input: &[u8], output: &mut [u8]) {
-    //
-    let len = input.len();
-    let len_u32 = len / 4;
-
-    let input_u32 = [0u32; 16];
-    read_u32v_le(&mut input_u32, &input);
-
-    unsafe {
-        let input_ptr = transmute::<&[u32], &[u32x4]>(input_u32);
-    }
-
-    let state = SalsaState {
-        a: input_ptr[0],
-        b: input_ptr[1],
-        c: input_ptr[2],
-        d: input_ptr[3]
-    };
-
-    let state_orig = state;
-
-    // let state = SalsaState {
-    //     a: u32x4(input_u32[0], input_u32[1], input_u32[2], input_u32[3]),
-    //     b: u32x4(input_u32[4], input_u32[5], input_u32[6], input_u32[7]),
-    //     c: u32x4(input_u32[8], input_u32[9], input_u32[10], input_u32[11]),
-    //     d: u32x4(input_u32[12], input_u32[13], input_u32[14], input_u32[15])
-    // };
-
-    for _ in range(0, 4) {
-        columnround(&mut state);
-        prepare_rowround!(a, b, c);
-        rowround(&mut state);
-        prepare_columnround!(a, b, c);
-    }
-
-    let u32x4(x4, x9, x14, x3) = state.a + state_orig.a;
-    let u32x4(x8, x13, x2, x7) = state.b + state_orig.b;
-    let u32x4(x12, x1, x6, x11) = state.c + state_orig.c;
-    let u32x4(x0, x5, x10, x15) = state.d + state_orig.d;
-    let lens = [
-         x0,  x1,  x2,  x3,
-         x4,  x5,  x6,  x7,
-         x8,  x9, x10, x11,
-        x12, x13, x14, x15
-    ];
-
-    for i in range(0, lens.len()) {
-        write_u32_le(&mut self.output[i*4..(i+1)*4], lens[i]);
-    }
-}
 
 // The salsa20/8 core function.
 fn salsa20_8(input: &[u8], output: &mut [u8]) {


### PR DESCRIPTION
Apologies, there was a error in my pull request for adding the SOSEMANUK cipher that didn't get caught due to the whole problem with the rust nightly binary. I thought I'd tested the latest test vectors that I added but it turns out I didn't, and there was a slight error (declared incorrect size for array that caused test to fail).

This new pull request is for adding the HC-128 stream cipher, and fixing the SOSEMANUK problem. I couldn't put it in two different pull requests (as I'd have liked to for tidiness), because they share a dependency on a u32-vector writing function that I added.
The SOSEMANUK cipher now writes its s-box output via this vector method, and is about 40 MB/s better for doing do.

The HC-128 cipher is amazingly fast.
Here's an output from cargo bench:

test hc128::bench::hc128_10                        ... bench:        19 ns/iter (+/- 4) = 526 MB/s
test hc128::bench::hc128_1k                        ... bench:      1381 ns/iter (+/- 419) = 741 MB/s
test hc128::bench::hc128_64k                       ... bench:     87997 ns/iter (+/- 22266) = 744 MB/s
test sosemanuk::bench::sosemanuk_10                ... bench:        35 ns/iter (+/- 7) = 285 MB/s
test sosemanuk::bench::sosemanuk_1k                ... bench:      3127 ns/iter (+/- 879) = 327 MB/s
test sosemanuk::bench::sosemanuk_64k               ... bench:    202977 ns/iter (+/- 19874) = 322 MB/s

and Salsa20 for comparison:
test salsa20::bench::salsa20_10                    ... bench:        36 ns/iter (+/- 24) = 277 MB/s
test salsa20::bench::salsa20_1k                    ... bench:      2117 ns/iter (+/- 363) = 483 MB/s
test salsa20::bench::salsa20_64k                   ... bench:    134849 ns/iter (+/- 13232) = 485 MB/s

This makes HC-128 the fastest cipher implemented so far (apart from AES-NI, which has a bit of an unfair advantage) by a good margin. A part of this may be the extra logic I added in the process() function in the SynchronousStreamCipher impl for processing input blockwise rather than bytewise. This approach could easily be moved to other ciphers... I just haven't done it yet.