### PR TITLE
Add HC-128 cipher, and fix error in SOSEMANUK cipher test unit.

### DIFF
--- a/src/cryptoutil.rs
+++ b/src/cryptoutil.rs
@@ -77,6 +77,21 @@ pub fn write_u32_le(dst: &mut[u8], mut input: u32) {
     }
 }
 
+/// Write a vector of u32s into a vector of bytes. The values are written in little-endian format.
+pub fn write_u32v_le (dst: &mut[u8], input: &[u32]) {
+    assert!(dst.len() == 4 * input.len());
+    unsafe {
+        let mut x: *mut u8 = dst.get_unchecked_mut(0);
+        let mut y: *const u32 = input.get_unchecked(0);
+        for _ in range(0, input.len()) {
+            let tmp = (*y).to_le();
+            ptr::copy_nonoverlapping_memory(x, &tmp as *const _ as *const u8, 4);
+            x = x.offset(4);
+            y = y.offset(1);
+        }
+    }
+}
+
 /// Read a vector of bytes into a vector of u64s. The values are read in big-endian format.
 pub fn read_u64v_be(dst: &mut[u64], input: &[u8]) {
     assert!(dst.len() * 8 == input.len());

--- a/src/hc128.rs
+++ b/src/hc128.rs
@@ -1,0 +1,294 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+ 
+ 
+use buffer::{BufferResult, RefReadBuffer, RefWriteBuffer};
+use symmetriccipher::{Encryptor, Decryptor, SynchronousStreamCipher, SymmetricCipherError};
+use cryptoutil::{read_u32_le, symm_enc_or_dec, write_u32_le, write_u32v_le};
+ 
+use std::num::Int;
+use std::slice::bytes::copy_memory;
+
+use std::ptr;
+use std::intrinsics::offset;
+
+
+#[derive(Copy)]
+struct Hc128 {
+    p: [u32; 512],
+    q: [u32; 512],
+    cnt: usize,
+    output: [u8; 4],
+    output_index: usize
+}
+ 
+impl Hc128 {
+    pub fn new(key: &[u8], nonce: &[u8]) -> Hc128 {
+        assert!(key.len() == 16);
+        assert!(nonce.len() == 16);
+        let mut hc128 = Hc128 { p: [0; 512], q: [0; 512], cnt: 0, output: [0; 4], output_index: 0 };
+        hc128.init(&key, &nonce);
+ 
+        hc128
+    }
+
+    fn init(&mut self, key : &[u8], nonce : &[u8]) {
+        self.cnt = 0;
+
+        let mut w : [u32; 1280] = [0; 1280];
+
+        for i in range(0, 16) {
+            w[i >> 2] |= ((key[i] as u32) << (8 * (i & 0x3)));
+        }
+        unsafe {
+            ptr::copy_nonoverlapping_memory(w.as_mut_ptr().offset(4), w.as_ptr(), 4);
+        }
+
+        for i in range(0, nonce.len() & 16) {
+            w[(i >> 2) + 8] |= ((nonce[i] as u32) << (8 * (i & 0x3)));
+        }
+        unsafe {
+            ptr::copy_nonoverlapping_memory(w.as_mut_ptr().offset(12), w.as_ptr().offset(8), 4);
+        }
+
+        for i in range(16, 1280) {
+            w[i] = (f2(w[i - 2]) + w[i - 7] + f1(w[i - 15]) + w[i - 16] + (i as u32)) as u32;
+        }
+
+        // Copy contents of w into p and q
+        unsafe {
+            ptr::copy_nonoverlapping_memory(self.p.as_mut_ptr(), w.as_ptr().offset(256), 512);
+            ptr::copy_nonoverlapping_memory(self.q.as_mut_ptr(), w.as_ptr().offset(768), 512);
+        }
+        
+        for i in range(0, 512) {
+            self.p[i] = self.step();
+        }
+        for i in range(0, 512) {
+            self.q[i] = self.step();
+        }  
+     
+        self.cnt = 0;
+    }
+ 
+    fn step(&mut self) -> u32 {
+        let j : usize = self.cnt & 0x1FF;
+
+        // Precompute resources
+        let dimJ3 : usize = (j - 3) & 0x1FF;
+        let dimJ10 : usize = (j - 10) & 0x1FF;
+        let dimJ511 : usize = (j - 511) & 0x1FF;
+        let dimJ12 : usize = (j - 12) & 0x1FF;
+
+        let mut ret : u32;
+
+        if (self.cnt < 512) {
+            self.p[j] += (self.p[dimJ3].rotate_right(10) ^ self.p[dimJ511].rotate_right(23)) + self.p[dimJ10].rotate_right(8);
+            ret = (self.q[(self.p[dimJ12] & 0xFF) as usize] + self.q[(((self.p[dimJ12] >> 16) & 0xFF) + 256) as usize]) ^ self.p[j];
+        } else {
+            self.q[j] += (self.q[dimJ3].rotate_left(10) ^ self.q[dimJ511].rotate_left(23)) + self.q[dimJ10].rotate_left(8);
+            ret = (self.p[(self.q[dimJ12] & 0xFF) as usize] + self.p[(((self.q[dimJ12] >> 16) & 0xFF) + 256) as usize]) ^ self.q[j];
+        }
+
+        self.cnt = (self.cnt + 1) & 0x3FF;    
+        ret
+    }
+ 
+    fn next(&mut self) -> u8 {
+        if self.output_index == 0 {
+            let step = self.step();
+            write_u32_le(&mut self.output, step);
+        }
+        let ret = self.output[self.output_index];
+        self.output_index = (self.output_index + 1) & 0x3;
+
+        ret
+    }
+}
+
+fn f1(x: u32) -> u32 {
+    let ret : u32 = x.rotate_right(7) ^ x.rotate_right(18) ^ (x >> 3);
+    ret
+}
+
+fn f2(x: u32) -> u32 {
+    let ret : u32 = x.rotate_right(17) ^ x.rotate_right(19) ^ (x >> 10);
+    ret
+}
+
+impl SynchronousStreamCipher for Hc128 {
+    fn process(&mut self, input: &[u8], output: &mut [u8]) {
+        assert!(input.len() == output.len());
+
+        if input.len() <= 4 {
+            // Process data bytewise
+            for (inb, outb) in input.iter().zip(output.iter_mut()) {
+                *outb = *inb ^ self.next();
+            }
+        } else {
+            let mut data_index = 0 as usize;
+            let data_index_end = data_index + input.len();
+
+            /*  Process any unused keystream (self.buffer) 
+             *  remaining from previous operations */
+            while self.output_index > 0 && data_index < data_index_end {
+                output[data_index] = input[data_index] ^ self.next();
+                data_index += 1;
+            }
+
+            /*  Process input data blockwise until depleted, 
+             *  or remaining length less than block size 
+             *  (size of the keystream buffer, self.buffer : 4 bytes) */
+            while data_index + 4 <= data_index_end {
+                let data_index_inc = data_index + 4;
+
+                // Read input as le-u32
+                let input_u32 = read_u32_le(&input[data_index..data_index_inc]);
+                // XOR with keystream u32
+                let xored = input_u32 ^ self.step();
+                // Write output as le-u32
+                write_u32_le(&mut output[data_index..data_index_inc], xored);
+
+                data_index = data_index_inc;
+            }
+
+            /*  Process remaining data, if any 
+             *  (e.g. input length not divisible by 4) */
+            while data_index < data_index_end {
+                output[data_index] = input[data_index] ^ self.next();
+                data_index += 1;
+            }
+        }
+    }
+}
+ 
+impl Encryptor for Hc128 {
+    fn encrypt(&mut self, input: &mut RefReadBuffer, output: &mut RefWriteBuffer, _: bool)
+            -> Result<BufferResult, SymmetricCipherError> {
+        symm_enc_or_dec(self, input, output)
+    }
+}
+ 
+impl Decryptor for Hc128 {
+    fn decrypt(&mut self, input: &mut RefReadBuffer, output: &mut RefWriteBuffer, _: bool)
+            -> Result<BufferResult, SymmetricCipherError> {
+        symm_enc_or_dec(self, input, output)
+    }
+}
+
+ 
+// #[cfg(test)]
+mod test {
+    use hc128::Hc128;
+    use symmetriccipher::SynchronousStreamCipher;
+    use serialize::hex::{FromHex, ToHex};
+
+    // Vectors from http://www.ecrypt.eu.org/stream/svn/viewcvs.cgi/ecrypt/trunk/submissions/hc-256/hc-128/verified.test-vectors?rev=210&view=markup
+
+    #[test]
+    fn test_hc128_ecrypt_set_2_vector_0() {
+        let key = "00000000000000000000000000000000".from_hex().unwrap();
+        let nonce = "00000000000000000000000000000000".from_hex().unwrap();
+
+        let input = [0u8; 64];
+        let expected_output_hex = "82001573A003FD3B7FD72FFB0EAF63AAC62F12DEB629DCA72785A66268EC758B1EDB36900560898178E0AD009ABF1F491330DC1C246E3D6CB264F6900271D59C";
+        let expected_output = expected_output_hex.from_hex().unwrap();
+
+        let mut output = [0u8; 64];
+ 
+        let mut hc128 = Hc128::new(key.as_slice(), nonce.as_slice());
+        hc128.process(&input, &mut output);
+        assert!(output.as_slice() == expected_output.as_slice());
+    }
+
+    #[test]
+    fn test_hc128_ecrypt_set_6_vector_1() {
+        let key = "0558ABFE51A4F74A9DF04396E93C8FE2".from_hex().unwrap();
+        let nonce = "167DE44BB21980E74EB51C83EA51B81F".from_hex().unwrap();
+
+        let input = [0u8; 64];
+        let expected_output_hex = "4F864BF3C96D0363B1903F0739189138F6ED2BC0AF583FEEA0CEA66BA7E06E63FB28BF8B3CA0031D24ABB511C57DD17BFC2861C32400072CB680DF2E58A5CECC";
+        let expected_output = expected_output_hex.from_hex().unwrap();
+
+        let mut output = [0u8; 64];
+ 
+        let mut hc128 = Hc128::new(key.as_slice(), nonce.as_slice());
+        hc128.process(&input, &mut output);
+        assert!(output.as_slice() == expected_output.as_slice());
+    }
+
+    #[test]
+    fn test_hc128_ecrypt_set_6_vector_2() {
+        let key = "0A5DB00356A9FC4FA2F5489BEE4194E7".from_hex().unwrap();
+        let nonce = "1F86ED54BB2289F057BE258CF35AC128".from_hex().unwrap();
+
+        let input = [0u8; 64];
+        let expected_output_hex = "82168AB0023B79AAF1E6B4D823855E14A7084378036A951B1CFEF35173875ED86CB66AB8410491A08582BE40080C3102193BA567F9E95D096C3CC60927DD7901";
+        let expected_output = expected_output_hex.from_hex().unwrap();
+
+        let mut output = [0u8; 64];
+ 
+        let mut hc128 = Hc128::new(key.as_slice(), nonce.as_slice());
+        hc128.process(&input, &mut output);
+        assert!(output.as_slice() == expected_output.as_slice());
+    }
+
+    #[test]
+    fn test_hc128_ecrypt_set_6_vector_3() {
+        let key = "0F62B5085BAE0154A7FA4DA0F34699EC".from_hex().unwrap();
+        let nonce = "288FF65DC42B92F960C72E95FC63CA31".from_hex().unwrap();
+
+        let input = [0u8; 64];
+        let expected_output_hex = "1CD8AEDDFE52E217E835D0B7E84E2922D04B1ADBCA53C4522B1AA604C42856A90AF83E2614BCE65C0AECABDD8975B55700D6A26D52FFF0888DA38F1DE20B77B7";
+        let expected_output = expected_output_hex.from_hex().unwrap();
+
+        let mut output = [0u8; 64];
+ 
+        let mut hc128 = Hc128::new(key.as_slice(), nonce.as_slice());
+        hc128.process(&input, &mut output);
+        assert!(output.as_slice() == expected_output.as_slice());
+    }
+}
+ 
+#[cfg(test)]
+mod bench {
+    use test::Bencher;
+    use symmetriccipher::SynchronousStreamCipher;
+    use hc128::Hc128;
+ 
+    #[bench]
+    pub fn hc128_10(bh: & mut Bencher) {
+        let mut hc128 = Hc128::new(&[0; 16], &[0; 16]);
+        let input = [1u8; 10];
+        let mut output = [0u8; 10];
+        bh.iter( || {
+            hc128.process(&input, &mut output);
+        });
+        bh.bytes = input.len() as u64;
+    }
+   
+    #[bench]
+    pub fn hc128_1k(bh: & mut Bencher) {
+        let mut hc128 = Hc128::new(&[0; 16], &[0; 16]);
+        let input = [1u8; 1024];
+        let mut output = [0u8; 1024];
+        bh.iter( || {
+            hc128.process(&input, &mut output);
+        });
+        bh.bytes = input.len() as u64;
+    }
+ 
+    #[bench]
+    pub fn hc128_64k(bh: & mut Bencher) {
+        let mut hc128 = Hc128::new(&[0; 16], &[0; 16]);
+        let input = [1u8; 65536];
+        let mut output = [0u8; 65536];
+        bh.iter( || {
+            hc128.process(&input, &mut output);
+        });
+        bh.bytes = input.len() as u64;
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@ pub mod digest;
 pub mod ed25519;
 pub mod fortuna;
 pub mod ghash;
+pub mod hc128;
 pub mod hmac;
 pub mod hkdf;
 pub mod mac;

--- a/src/sosemanuk.rs
+++ b/src/sosemanuk.rs
@@ -163,7 +163,7 @@ impl Sosemanuk {
     pub fn new(key: &[u8], nonce: &[u8]) -> Sosemanuk {
         let mut sosemanuk = Sosemanuk { lfsr: [0; 10], fsm_r: [0; 2], subkeys: [0; 100], output: [0; 80], offset: 80 };
  
-        //assert!(key.len() >= 16 && key.len() <= 32);
+        assert!(key.len() <= 32);
         assert!(nonce.len() <= 16);
        
         key_setup(&key, &mut sosemanuk.subkeys);
@@ -194,7 +194,6 @@ impl Sosemanuk {
         let mut v1 : u32;
         let mut v2 : u32;
         let mut v3 : u32;
-        let mut v4 : u32;
         let mut tt : u32;
  
         let ref mul_alpha = ALPHA_MUL_TABLE;
@@ -202,7 +201,7 @@ impl Sosemanuk {
  
         tt = r1;
         //r1 = r2 + (s1 ^ ((r1 & 0x01) != 0 ? s8 : 0));
-        r1 = r2 + (s1 ^ match (r1 & 0x01) {
+        r1 = r2 + (s1 ^ match r1 & 0x01 {
             0 => 0,
             _ => s8
         });
@@ -214,7 +213,7 @@ impl Sosemanuk {
  
         tt = r1;
         //r1 = r2 + (s2 ^ ((r1 & 0x01) != 0 ? s9 : 0));
-        r1 = r2 + (s2 ^ match (r1 & 0x01) {
+        r1 = r2 + (s2 ^ match r1 & 0x01 {
             0 => 0,
             _ => s9
         });
@@ -226,7 +225,7 @@ impl Sosemanuk {
  
         tt = r1;
         //r1 = r2 + (s3 ^ ((r1 & 0x01) != 0 ? s0 : 0));
-        r1 = r2 + (s3 ^ match (r1 & 0x01) {
+        r1 = r2 + (s3 ^ match r1 & 0x01 {
             0 => 0,
             _ => s0
         });
@@ -238,7 +237,7 @@ impl Sosemanuk {
  
         tt = r1;
         //r1 = r2 + (s4 ^ ((r1 & 0x01) != 0 ? s1 : 0));
-        r1 = r2 + (s4 ^ match (r1 & 0x01) {
+        r1 = r2 + (s4 ^ match r1 & 0x01 {
             0 => 0,
             _ => s1
         });
@@ -276,7 +275,7 @@ impl Sosemanuk {
 
         tt = r1;
         //r1 = r2 + (s5 ^ ((r1 & 0x01) != 0 ? s2 : 0));
-        r1 = r2 + (s5 ^ match (r1 & 0x01) {
+        r1 = r2 + (s5 ^ match r1 & 0x01 {
             0 => 0,
             _ => s2
         });
@@ -288,7 +287,7 @@ impl Sosemanuk {
  
         tt = r1;
         //r1 = r2 + (s6 ^ ((r1 & 0x01) != 0 ? s3 : 0));
-        r1 = r2 + (s6 ^ match (r1 & 0x01) {
+        r1 = r2 + (s6 ^ match r1 & 0x01 {
             0 => 0,
             _ => s3
         });
@@ -300,7 +299,7 @@ impl Sosemanuk {
  
         tt = r1;
         //r1 = r2 + (s7 ^ ((r1 & 0x01) != 0 ? s4 : 0));
-        r1 = r2 + (s7 ^ match (r1 & 0x01) {
+        r1 = r2 + (s7 ^ match r1 & 0x01 {
             0 => 0,
             _ => s4
         });
@@ -312,7 +311,7 @@ impl Sosemanuk {
  
         tt = r1;
         //r1 = r2 + (s8 ^ ((r1 & 0x01) != 0 ? s5 : 0));
-        r1 = r2 + (s8 ^ match (r1 & 0x01) {
+        r1 = r2 + (s8 ^ match r1 & 0x01 {
             0 => 0,
             _ => s5
         });
@@ -350,7 +349,7 @@ impl Sosemanuk {
 
         tt = r1;
         //r1 = r2 + (s9 ^ ((r1 & 0x01) != 0 ? s6 : 0));
-        r1 = r2 + (s9 ^ match (r1 & 0x01) {
+        r1 = r2 + (s9 ^ match r1 & 0x01 {
             0 => 0,
             _ => s6
         });
@@ -362,7 +361,7 @@ impl Sosemanuk {
  
         tt = r1;
         //r1 = r2 + (s0 ^ ((r1 & 0x01) != 0 ? s7 : 0));
-        r1 = r2 + (s0 ^ match (r1 & 0x01) {
+        r1 = r2 + (s0 ^ match r1 & 0x01 {
             0 => 0,
             _ => s7
         });
@@ -374,7 +373,7 @@ impl Sosemanuk {
  
         tt = r1;
         //r1 = r2 + (s1 ^ ((r1 & 0x01) != 0 ? s8 : 0));
-        r1 = r2 + (s1 ^ match (r1 & 0x01) {
+        r1 = r2 + (s1 ^ match r1 & 0x01 {
             0 => 0,
             _ => s8
         });
@@ -386,7 +385,7 @@ impl Sosemanuk {
  
         tt = r1;
         //r1 = r2 + (s2 ^ ((r1 & 0x01) != 0 ? s9 : 0));
-        r1 = r2 + (s2 ^ match (r1 & 0x01) {
+        r1 = r2 + (s2 ^ match r1 & 0x01 {
             0 => 0,
             _ => s9
         });
@@ -424,7 +423,7 @@ impl Sosemanuk {
 
         tt = r1;
         //r1 = r2 + (s3 ^ ((r1 & 0x01) != 0 ? s0 : 0));
-        r1 = r2 + (s3 ^ match (r1 & 0x01) {
+        r1 = r2 + (s3 ^ match r1 & 0x01 {
             0 => 0,
             _ => s0
         });
@@ -436,7 +435,7 @@ impl Sosemanuk {
  
         tt = r1;
         //r1 = r2 + (s4 ^ ((r1 & 0x01) != 0 ? s1 : 0));
-        r1 = r2 + (s4 ^ match (r1 & 0x01) {
+        r1 = r2 + (s4 ^ match r1 & 0x01 {
             0 => 0,
             _ => s1
         });
@@ -448,7 +447,7 @@ impl Sosemanuk {
  
         tt = r1;
         //r1 = r2 + (s5 ^ ((r1 & 0x01) != 0 ? s2 : 0));
-        r1 = r2 + (s5 ^ match (r1 & 0x01) {
+        r1 = r2 + (s5 ^ match r1 & 0x01 {
             0 => 0,
             _ => s2
         });
@@ -460,7 +459,7 @@ impl Sosemanuk {
  
         tt = r1;
         //r1 = r2 + (s6 ^ ((r1 & 0x01) != 0 ? s3 : 0));
-        r1 = r2 + (s6 ^ match (r1 & 0x01) {
+        r1 = r2 + (s6 ^ match r1 & 0x01 {
             0 => 0,
             _ => s3
         });
@@ -498,7 +497,7 @@ impl Sosemanuk {
  
         tt = r1;
         //r1 = r2 + (s7 ^ ((r1 & 0x01) != 0 ? s4 : 0));
-        r1 = r2 + (s7 ^ match (r1 & 0x01) {
+        r1 = r2 + (s7 ^ match r1 & 0x01 {
             0 => 0,
             _ => s4
         });
@@ -510,7 +509,7 @@ impl Sosemanuk {
  
         tt = r1;
         //r1 = r2 + (s8 ^ ((r1 & 0x01) != 0 ? s5 : 0));
-        r1 = r2 + (s8 ^ match (r1 & 0x01) {
+        r1 = r2 + (s8 ^ match r1 & 0x01 {
             0 => 0,
             _ => s5
         });
@@ -522,7 +521,7 @@ impl Sosemanuk {
  
         tt = r1;
         //r1 = r2 + (s9 ^ ((r1 & 0x01) != 0 ? s6 : 0));
-        r1 = r2 + (s9 ^ match (r1 & 0x01) {
+        r1 = r2 + (s9 ^ match r1 & 0x01 {
             0 => 0,
             _ => s6
         });
@@ -534,7 +533,7 @@ impl Sosemanuk {
  
         tt = r1;
         //r1 = r2 + (s0 ^ ((r1 & 0x01) != 0 ? s7 : 0));
-        r1 = r2 + (s0 ^ match (r1 & 0x01) {
+        r1 = r2 + (s0 ^ match r1 & 0x01 {
             0 => 0,
             _ => s7
         });
@@ -621,13 +620,13 @@ fn key_setup(key : &[u8], subkeys : &mut[u32; 100]) {
     let mut tt : u32;
     let mut i = 0 as usize;
  
-    tt = (w0 ^ w3 ^ w5 ^ w7 ^ (0x9E3779B9 ^ (0)));
+    tt = w0 ^ w3 ^ w5 ^ w7 ^ (0x9E3779B9 ^ (0));
     w0 = tt.rotate_left(11);
-    tt = (w1 ^ w4 ^ w6 ^ w0 ^ (0x9E3779B9 ^ (0 + 1)));
+    tt = w1 ^ w4 ^ w6 ^ w0 ^ (0x9E3779B9 ^ (0 + 1));
     w1 = tt.rotate_left(11);
-    tt = (w2 ^ w5 ^ w7 ^ w1 ^ (0x9E3779B9 ^ (0 + 2)));
+    tt = w2 ^ w5 ^ w7 ^ w1 ^ (0x9E3779B9 ^ (0 + 2));
     w2 = tt.rotate_left(11);
-    tt = (w3 ^ w6 ^ w0 ^ w2 ^ (0x9E3779B9 ^ (0 + 3)));
+    tt = w3 ^ w6 ^ w0 ^ w2 ^ (0x9E3779B9 ^ (0 + 3));
     w3 = tt.rotate_left(11);
     r0 = w0;
     r1 = w1;
@@ -656,13 +655,13 @@ fn key_setup(key : &[u8], subkeys : &mut[u32; 100]) {
     subkeys[i] = r2; i+=1;
     subkeys[i] = r3; i+=1;
     subkeys[i] = r4; i+=1;
-    tt =  (w4 ^ w7 ^ w1 ^ w3 ^ (0x9E3779B9 ^ (4)));
+    tt = w4 ^ w7 ^ w1 ^ w3 ^ (0x9E3779B9 ^ (4));
     w4 = tt.rotate_left(11);
-    tt =  (w5 ^ w0 ^ w2 ^ w4 ^ (0x9E3779B9 ^ (4 + 1)));
+    tt = w5 ^ w0 ^ w2 ^ w4 ^ (0x9E3779B9 ^ (4 + 1));
     w5 = tt.rotate_left(11);
-    tt =  (w6 ^ w1 ^ w3 ^ w5 ^ (0x9E3779B9 ^ (4 + 2)));
+    tt = w6 ^ w1 ^ w3 ^ w5 ^ (0x9E3779B9 ^ (4 + 2));
     w6 = tt.rotate_left(11);
-    tt =  (w7 ^ w2 ^ w4 ^ w6 ^ (0x9E3779B9 ^ (4 + 3)));
+    tt = w7 ^ w2 ^ w4 ^ w6 ^ (0x9E3779B9 ^ (4 + 3));
     w7 = tt.rotate_left(11);
     r0 = w4;
     r1 = w5;
@@ -688,13 +687,13 @@ fn key_setup(key : &[u8], subkeys : &mut[u32; 100]) {
     subkeys[i] = r3; i+=1;
     subkeys[i] = r1; i+=1;
     subkeys[i] = r4; i+=1;
-    tt =  (w0 ^ w3 ^ w5 ^ w7 ^ (0x9E3779B9 ^ (8)));
+    tt = w0 ^ w3 ^ w5 ^ w7 ^ (0x9E3779B9 ^ (8));
     w0 = tt.rotate_left(11);
-    tt =  (w1 ^ w4 ^ w6 ^ w0 ^ (0x9E3779B9 ^ (8 + 1)));
+    tt = w1 ^ w4 ^ w6 ^ w0 ^ (0x9E3779B9 ^ (8 + 1));
     w1 = tt.rotate_left(11);
-    tt =  (w2 ^ w5 ^ w7 ^ w1 ^ (0x9E3779B9 ^ (8 + 2)));
+    tt = w2 ^ w5 ^ w7 ^ w1 ^ (0x9E3779B9 ^ (8 + 2));
     w2 = tt.rotate_left(11);
-    tt =  (w3 ^ w6 ^ w0 ^ w2 ^ (0x9E3779B9 ^ (8 + 3)));
+    tt = w3 ^ w6 ^ w0 ^ w2 ^ (0x9E3779B9 ^ (8 + 3));
     w3 = tt.rotate_left(11);
     r0 = w0;
     r1 = w1;
@@ -722,13 +721,13 @@ fn key_setup(key : &[u8], subkeys : &mut[u32; 100]) {
     subkeys[i] = r0; i+=1;
     subkeys[i] = r3; i+=1;
     subkeys[i] = r1; i+=1;
-    tt =  (w4 ^ w7 ^ w1 ^ w3 ^ (0x9E3779B9 ^ (12)));
+    tt = w4 ^ w7 ^ w1 ^ w3 ^ (0x9E3779B9 ^ (12));
     w4 = tt.rotate_left(11);
-    tt =  (w5 ^ w0 ^ w2 ^ w4 ^ (0x9E3779B9 ^ (12 + 1)));
+    tt = w5 ^ w0 ^ w2 ^ w4 ^ (0x9E3779B9 ^ (12 + 1));
     w5 = tt.rotate_left(11);
-    tt =  (w6 ^ w1 ^ w3 ^ w5 ^ (0x9E3779B9 ^ (12 + 2)));
+    tt = w6 ^ w1 ^ w3 ^ w5 ^ (0x9E3779B9 ^ (12 + 2));
     w6 = tt.rotate_left(11);
-    tt =  (w7 ^ w2 ^ w4 ^ w6 ^ (0x9E3779B9 ^ (12 + 3)));
+    tt = w7 ^ w2 ^ w4 ^ w6 ^ (0x9E3779B9 ^ (12 + 3));
     w7 = tt.rotate_left(11);
     r0 = w4;
     r1 = w5;
@@ -756,13 +755,13 @@ fn key_setup(key : &[u8], subkeys : &mut[u32; 100]) {
     subkeys[i] = r4; i+=1;
     subkeys[i] = r2; i+=1;
     subkeys[i] = r0; i+=1;
-    tt =  (w0 ^ w3 ^ w5 ^ w7 ^ (0x9E3779B9 ^ (16)));
+    tt = w0 ^ w3 ^ w5 ^ w7 ^ (0x9E3779B9 ^ (16));
     w0 = tt.rotate_left(11);
-    tt =  (w1 ^ w4 ^ w6 ^ w0 ^ (0x9E3779B9 ^ (16 + 1)));
+    tt = w1 ^ w4 ^ w6 ^ w0 ^ (0x9E3779B9 ^ (16 + 1));
     w1 = tt.rotate_left(11);
-    tt =  (w2 ^ w5 ^ w7 ^ w1 ^ (0x9E3779B9 ^ (16 + 2)));
+    tt = w2 ^ w5 ^ w7 ^ w1 ^ (0x9E3779B9 ^ (16 + 2));
     w2 = tt.rotate_left(11);
-    tt =  (w3 ^ w6 ^ w0 ^ w2 ^ (0x9E3779B9 ^ (16 + 3)));
+    tt = w3 ^ w6 ^ w0 ^ w2 ^ (0x9E3779B9 ^ (16 + 3));
     w3 = tt.rotate_left(11);
     r0 = w0;
     r1 = w1;
@@ -792,13 +791,13 @@ fn key_setup(key : &[u8], subkeys : &mut[u32; 100]) {
     subkeys[i] = r3; i+=1;
     subkeys[i] = r1; i+=1;
     subkeys[i] = r0; i+=1;
-    tt =  (w4 ^ w7 ^ w1 ^ w3 ^ (0x9E3779B9 ^ (20)));
+    tt = w4 ^ w7 ^ w1 ^ w3 ^ (0x9E3779B9 ^ (20));
     w4 = tt.rotate_left(11);
-    tt =  (w5 ^ w0 ^ w2 ^ w4 ^ (0x9E3779B9 ^ (20 + 1)));
+    tt = w5 ^ w0 ^ w2 ^ w4 ^ (0x9E3779B9 ^ (20 + 1));
     w5 = tt.rotate_left(11);
-    tt =  (w6 ^ w1 ^ w3 ^ w5 ^ (0x9E3779B9 ^ (20 + 2)));
+    tt = w6 ^ w1 ^ w3 ^ w5 ^ (0x9E3779B9 ^ (20 + 2));
     w6 = tt.rotate_left(11);
-    tt =  (w7 ^ w2 ^ w4 ^ w6 ^ (0x9E3779B9 ^ (20 + 3)));
+    tt = w7 ^ w2 ^ w4 ^ w6 ^ (0x9E3779B9 ^ (20 + 3));
     w7 = tt.rotate_left(11);
     r0 = w4;
     r1 = w5;
@@ -826,13 +825,13 @@ fn key_setup(key : &[u8], subkeys : &mut[u32; 100]) {
     subkeys[i] = r1; i+=1;
     subkeys[i] = r4; i+=1;
     subkeys[i] = r2; i+=1;
-    tt =  (w0 ^ w3 ^ w5 ^ w7 ^ (0x9E3779B9 ^ (24)));
+    tt = w0 ^ w3 ^ w5 ^ w7 ^ (0x9E3779B9 ^ (24));
     w0 = tt.rotate_left(11);
-    tt =  (w1 ^ w4 ^ w6 ^ w0 ^ (0x9E3779B9 ^ (24 + 1)));
+    tt = w1 ^ w4 ^ w6 ^ w0 ^ (0x9E3779B9 ^ (24 + 1));
     w1 = tt.rotate_left(11);
-    tt =  (w2 ^ w5 ^ w7 ^ w1 ^ (0x9E3779B9 ^ (24 + 2)));
+    tt = w2 ^ w5 ^ w7 ^ w1 ^ (0x9E3779B9 ^ (24 + 2));
     w2 = tt.rotate_left(11);
-    tt =  (w3 ^ w6 ^ w0 ^ w2 ^ (0x9E3779B9 ^ (24 + 3)));
+    tt = w3 ^ w6 ^ w0 ^ w2 ^ (0x9E3779B9 ^ (24 + 3));
     w3 = tt.rotate_left(11);
     r0 = w0;
     r1 = w1;
@@ -861,13 +860,13 @@ fn key_setup(key : &[u8], subkeys : &mut[u32; 100]) {
     subkeys[i] = r3; i+=1;
     subkeys[i] = r0; i+=1;
     subkeys[i] = r2; i+=1;
-    tt =  (w4 ^ w7 ^ w1 ^ w3 ^ (0x9E3779B9 ^ (28)));
+    tt = w4 ^ w7 ^ w1 ^ w3 ^ (0x9E3779B9 ^ (28));
     w4 = tt.rotate_left(11);
-    tt =  (w5 ^ w0 ^ w2 ^ w4 ^ (0x9E3779B9 ^ (28 + 1)));
+    tt = w5 ^ w0 ^ w2 ^ w4 ^ (0x9E3779B9 ^ (28 + 1));
     w5 = tt.rotate_left(11);
-    tt =  (w6 ^ w1 ^ w3 ^ w5 ^ (0x9E3779B9 ^ (28 + 2)));
+    tt = w6 ^ w1 ^ w3 ^ w5 ^ (0x9E3779B9 ^ (28 + 2));
     w6 = tt.rotate_left(11);
-    tt =  (w7 ^ w2 ^ w4 ^ w6 ^ (0x9E3779B9 ^ (28 + 3)));
+    tt = w7 ^ w2 ^ w4 ^ w6 ^ (0x9E3779B9 ^ (28 + 3));
     w7 = tt.rotate_left(11);
     r0 = w4;
     r1 = w5;
@@ -897,13 +896,13 @@ fn key_setup(key : &[u8], subkeys : &mut[u32; 100]) {
     subkeys[i] = r4; i+=1;
     subkeys[i] = r0; i+=1;
     subkeys[i] = r3; i+=1;
-    tt =  (w0 ^ w3 ^ w5 ^ w7 ^ (0x9E3779B9 ^ (32)));
+    tt = w0 ^ w3 ^ w5 ^ w7 ^ (0x9E3779B9 ^ (32));
     w0 = tt.rotate_left(11);
-    tt =  (w1 ^ w4 ^ w6 ^ w0 ^ (0x9E3779B9 ^ (32 + 1)));
+    tt = w1 ^ w4 ^ w6 ^ w0 ^ (0x9E3779B9 ^ (32 + 1));
     w1 = tt.rotate_left(11);
-    tt =  (w2 ^ w5 ^ w7 ^ w1 ^ (0x9E3779B9 ^ (32 + 2)));
+    tt = w2 ^ w5 ^ w7 ^ w1 ^ (0x9E3779B9 ^ (32 + 2));
     w2 = tt.rotate_left(11);
-    tt =  (w3 ^ w6 ^ w0 ^ w2 ^ (0x9E3779B9 ^ (32 + 3)));
+    tt = w3 ^ w6 ^ w0 ^ w2 ^ (0x9E3779B9 ^ (32 + 3));
     w3 = tt.rotate_left(11);
     r0 = w0;
     r1 = w1;
@@ -932,13 +931,13 @@ fn key_setup(key : &[u8], subkeys : &mut[u32; 100]) {
     subkeys[i] = r2; i+=1;
     subkeys[i] = r3; i+=1;
     subkeys[i] = r4; i+=1;
-    tt =  (w4 ^ w7 ^ w1 ^ w3 ^ (0x9E3779B9 ^ (36)));
+    tt = w4 ^ w7 ^ w1 ^ w3 ^ (0x9E3779B9 ^ (36));
     w4 = tt.rotate_left(11);
-    tt =  (w5 ^ w0 ^ w2 ^ w4 ^ (0x9E3779B9 ^ (36 + 1)));
+    tt = w5 ^ w0 ^ w2 ^ w4 ^ (0x9E3779B9 ^ (36 + 1));
     w5 = tt.rotate_left(11);
-    tt =  (w6 ^ w1 ^ w3 ^ w5 ^ (0x9E3779B9 ^ (36 + 2)));
+    tt = w6 ^ w1 ^ w3 ^ w5 ^ (0x9E3779B9 ^ (36 + 2));
     w6 = tt.rotate_left(11);
-    tt =  (w7 ^ w2 ^ w4 ^ w6 ^ (0x9E3779B9 ^ (36 + 3)));
+    tt = w7 ^ w2 ^ w4 ^ w6 ^ (0x9E3779B9 ^ (36 + 3));
     w7 = tt.rotate_left(11);
     r0 = w4;
     r1 = w5;
@@ -964,13 +963,13 @@ fn key_setup(key : &[u8], subkeys : &mut[u32; 100]) {
     subkeys[i] = r3; i+=1;
     subkeys[i] = r1; i+=1;
     subkeys[i] = r4; i+=1;
-    tt =  (w0 ^ w3 ^ w5 ^ w7 ^ (0x9E3779B9 ^ (40)));
+    tt = w0 ^ w3 ^ w5 ^ w7 ^ (0x9E3779B9 ^ (40));
     w0 = tt.rotate_left(11);
-    tt =  (w1 ^ w4 ^ w6 ^ w0 ^ (0x9E3779B9 ^ (40 + 1)));
+    tt = w1 ^ w4 ^ w6 ^ w0 ^ (0x9E3779B9 ^ (40 + 1));
     w1 = tt.rotate_left(11);
-    tt =  (w2 ^ w5 ^ w7 ^ w1 ^ (0x9E3779B9 ^ (40 + 2)));
+    tt = w2 ^ w5 ^ w7 ^ w1 ^ (0x9E3779B9 ^ (40 + 2));
     w2 = tt.rotate_left(11);
-    tt =  (w3 ^ w6 ^ w0 ^ w2 ^ (0x9E3779B9 ^ (40 + 3)));
+    tt = w3 ^ w6 ^ w0 ^ w2 ^ (0x9E3779B9 ^ (40 + 3));
     w3 = tt.rotate_left(11);
     r0 = w0;
     r1 = w1;
@@ -998,13 +997,13 @@ fn key_setup(key : &[u8], subkeys : &mut[u32; 100]) {
     subkeys[i] = r0; i+=1;
     subkeys[i] = r3; i+=1;
     subkeys[i] = r1; i+=1;
-    tt =  (w4 ^ w7 ^ w1 ^ w3 ^ (0x9E3779B9 ^ (44)));
+    tt = w4 ^ w7 ^ w1 ^ w3 ^ (0x9E3779B9 ^ (44));
     w4 = tt.rotate_left(11);
-    tt =  (w5 ^ w0 ^ w2 ^ w4 ^ (0x9E3779B9 ^ (44 + 1)));
+    tt = w5 ^ w0 ^ w2 ^ w4 ^ (0x9E3779B9 ^ (44 + 1));
     w5 = tt.rotate_left(11);
-    tt =  (w6 ^ w1 ^ w3 ^ w5 ^ (0x9E3779B9 ^ (44 + 2)));
+    tt = w6 ^ w1 ^ w3 ^ w5 ^ (0x9E3779B9 ^ (44 + 2));
     w6 = tt.rotate_left(11);
-    tt =  (w7 ^ w2 ^ w4 ^ w6 ^ (0x9E3779B9 ^ (44 + 3)));
+    tt = w7 ^ w2 ^ w4 ^ w6 ^ (0x9E3779B9 ^ (44 + 3));
     w7 = tt.rotate_left(11);
     r0 = w4;
     r1 = w5;
@@ -1032,13 +1031,13 @@ fn key_setup(key : &[u8], subkeys : &mut[u32; 100]) {
     subkeys[i] = r4; i+=1;
     subkeys[i] = r2; i+=1;
     subkeys[i] = r0; i+=1;
-    tt =  (w0 ^ w3 ^ w5 ^ w7 ^ (0x9E3779B9 ^ (48)));
+    tt = w0 ^ w3 ^ w5 ^ w7 ^ (0x9E3779B9 ^ (48));
     w0 = tt.rotate_left(11);
-    tt =  (w1 ^ w4 ^ w6 ^ w0 ^ (0x9E3779B9 ^ (48 + 1)));
+    tt = w1 ^ w4 ^ w6 ^ w0 ^ (0x9E3779B9 ^ (48 + 1));
     w1 = tt.rotate_left(11);
-    tt =  (w2 ^ w5 ^ w7 ^ w1 ^ (0x9E3779B9 ^ (48 + 2)));
+    tt = w2 ^ w5 ^ w7 ^ w1 ^ (0x9E3779B9 ^ (48 + 2));
     w2 = tt.rotate_left(11);
-    tt =  (w3 ^ w6 ^ w0 ^ w2 ^ (0x9E3779B9 ^ (48 + 3)));
+    tt = w3 ^ w6 ^ w0 ^ w2 ^ (0x9E3779B9 ^ (48 + 3));
     w3 = tt.rotate_left(11);
     r0 = w0;
     r1 = w1;
@@ -1068,13 +1067,13 @@ fn key_setup(key : &[u8], subkeys : &mut[u32; 100]) {
     subkeys[i] = r3; i+=1;
     subkeys[i] = r1; i+=1;
     subkeys[i] = r0; i+=1;
-    tt =  (w4 ^ w7 ^ w1 ^ w3 ^ (0x9E3779B9 ^ (52)));
+    tt = w4 ^ w7 ^ w1 ^ w3 ^ (0x9E3779B9 ^ (52));
     w4 = tt.rotate_left(11);
-    tt =  (w5 ^ w0 ^ w2 ^ w4 ^ (0x9E3779B9 ^ (52 + 1)));
+    tt = w5 ^ w0 ^ w2 ^ w4 ^ (0x9E3779B9 ^ (52 + 1));
     w5 = tt.rotate_left(11);
-    tt =  (w6 ^ w1 ^ w3 ^ w5 ^ (0x9E3779B9 ^ (52 + 2)));
+    tt = w6 ^ w1 ^ w3 ^ w5 ^ (0x9E3779B9 ^ (52 + 2));
     w6 = tt.rotate_left(11);
-    tt =  (w7 ^ w2 ^ w4 ^ w6 ^ (0x9E3779B9 ^ (52 + 3)));
+    tt = w7 ^ w2 ^ w4 ^ w6 ^ (0x9E3779B9 ^ (52 + 3));
     w7 = tt.rotate_left(11);
     r0 = w4;
     r1 = w5;
@@ -1102,13 +1101,13 @@ fn key_setup(key : &[u8], subkeys : &mut[u32; 100]) {
     subkeys[i] = r1; i+=1;
     subkeys[i] = r4; i+=1;
     subkeys[i] = r2; i+=1;
-    tt =  (w0 ^ w3 ^ w5 ^ w7 ^ (0x9E3779B9 ^ (56)));
+    tt = w0 ^ w3 ^ w5 ^ w7 ^ (0x9E3779B9 ^ (56));
     w0 = tt.rotate_left(11);
-    tt =  (w1 ^ w4 ^ w6 ^ w0 ^ (0x9E3779B9 ^ (56 + 1)));
+    tt = w1 ^ w4 ^ w6 ^ w0 ^ (0x9E3779B9 ^ (56 + 1));
     w1 = tt.rotate_left(11);
-    tt =  (w2 ^ w5 ^ w7 ^ w1 ^ (0x9E3779B9 ^ (56 + 2)));
+    tt = w2 ^ w5 ^ w7 ^ w1 ^ (0x9E3779B9 ^ (56 + 2));
     w2 = tt.rotate_left(11);
-    tt =  (w3 ^ w6 ^ w0 ^ w2 ^ (0x9E3779B9 ^ (56 + 3)));
+    tt = w3 ^ w6 ^ w0 ^ w2 ^ (0x9E3779B9 ^ (56 + 3));
     w3 = tt.rotate_left(11);
     r0 = w0;
     r1 = w1;
@@ -1137,13 +1136,13 @@ fn key_setup(key : &[u8], subkeys : &mut[u32; 100]) {
     subkeys[i] = r3; i+=1;
     subkeys[i] = r0; i+=1;
     subkeys[i] = r2; i+=1;
-    tt =  (w4 ^ w7 ^ w1 ^ w3 ^ (0x9E3779B9 ^ (60)));
+    tt = w4 ^ w7 ^ w1 ^ w3 ^ (0x9E3779B9 ^ (60));
     w4 = tt.rotate_left(11);
-    tt =  (w5 ^ w0 ^ w2 ^ w4 ^ (0x9E3779B9 ^ (60 + 1)));
+    tt = w5 ^ w0 ^ w2 ^ w4 ^ (0x9E3779B9 ^ (60 + 1));
     w5 = tt.rotate_left(11);
-    tt =  (w6 ^ w1 ^ w3 ^ w5 ^ (0x9E3779B9 ^ (60 + 2)));
+    tt = w6 ^ w1 ^ w3 ^ w5 ^ (0x9E3779B9 ^ (60 + 2));
     w6 = tt.rotate_left(11);
-    tt =  (w7 ^ w2 ^ w4 ^ w6 ^ (0x9E3779B9 ^ (60 + 3)));
+    tt = w7 ^ w2 ^ w4 ^ w6 ^ (0x9E3779B9 ^ (60 + 3));
     w7 = tt.rotate_left(11);
     r0 = w4;
     r1 = w5;
@@ -1173,13 +1172,13 @@ fn key_setup(key : &[u8], subkeys : &mut[u32; 100]) {
     subkeys[i] = r4; i+=1;
     subkeys[i] = r0; i+=1;
     subkeys[i] = r3; i+=1;
-    tt =  (w0 ^ w3 ^ w5 ^ w7 ^ (0x9E3779B9 ^ (64)));
+    tt = w0 ^ w3 ^ w5 ^ w7 ^ (0x9E3779B9 ^ (64));
     w0 = tt.rotate_left(11);
-    tt =  (w1 ^ w4 ^ w6 ^ w0 ^ (0x9E3779B9 ^ (64 + 1)));
+    tt = w1 ^ w4 ^ w6 ^ w0 ^ (0x9E3779B9 ^ (64 + 1));
     w1 = tt.rotate_left(11);
-    tt =  (w2 ^ w5 ^ w7 ^ w1 ^ (0x9E3779B9 ^ (64 + 2)));
+    tt = w2 ^ w5 ^ w7 ^ w1 ^ (0x9E3779B9 ^ (64 + 2));
     w2 = tt.rotate_left(11);
-    tt =  (w3 ^ w6 ^ w0 ^ w2 ^ (0x9E3779B9 ^ (64 + 3)));
+    tt = w3 ^ w6 ^ w0 ^ w2 ^ (0x9E3779B9 ^ (64 + 3));
     w3 = tt.rotate_left(11);
     r0 = w0;
     r1 = w1;
@@ -1208,13 +1207,13 @@ fn key_setup(key : &[u8], subkeys : &mut[u32; 100]) {
     subkeys[i] = r2; i+=1;
     subkeys[i] = r3; i+=1;
     subkeys[i] = r4; i+=1;
-    tt =  (w4 ^ w7 ^ w1 ^ w3 ^ (0x9E3779B9 ^ (68)));
+    tt = w4 ^ w7 ^ w1 ^ w3 ^ (0x9E3779B9 ^ (68));
     w4 = tt.rotate_left(11);
-    tt =  (w5 ^ w0 ^ w2 ^ w4 ^ (0x9E3779B9 ^ (68 + 1)));
+    tt = w5 ^ w0 ^ w2 ^ w4 ^ (0x9E3779B9 ^ (68 + 1));
     w5 = tt.rotate_left(11);
-    tt =  (w6 ^ w1 ^ w3 ^ w5 ^ (0x9E3779B9 ^ (68 + 2)));
+    tt = w6 ^ w1 ^ w3 ^ w5 ^ (0x9E3779B9 ^ (68 + 2));
     w6 = tt.rotate_left(11);
-    tt =  (w7 ^ w2 ^ w4 ^ w6 ^ (0x9E3779B9 ^ (68 + 3)));
+    tt = w7 ^ w2 ^ w4 ^ w6 ^ (0x9E3779B9 ^ (68 + 3));
     w7 = tt.rotate_left(11);
     r0 = w4;
     r1 = w5;
@@ -1240,13 +1239,13 @@ fn key_setup(key : &[u8], subkeys : &mut[u32; 100]) {
     subkeys[i] = r3; i+=1;
     subkeys[i] = r1; i+=1;
     subkeys[i] = r4; i+=1;
-    tt =  (w0 ^ w3 ^ w5 ^ w7 ^ (0x9E3779B9 ^ (72)));
+    tt = w0 ^ w3 ^ w5 ^ w7 ^ (0x9E3779B9 ^ (72));
     w0 = tt.rotate_left(11);
-    tt =  (w1 ^ w4 ^ w6 ^ w0 ^ (0x9E3779B9 ^ (72 + 1)));
+    tt = w1 ^ w4 ^ w6 ^ w0 ^ (0x9E3779B9 ^ (72 + 1));
     w1 = tt.rotate_left(11);
-    tt =  (w2 ^ w5 ^ w7 ^ w1 ^ (0x9E3779B9 ^ (72 + 2)));
+    tt = w2 ^ w5 ^ w7 ^ w1 ^ (0x9E3779B9 ^ (72 + 2));
     w2 = tt.rotate_left(11);
-    tt =  (w3 ^ w6 ^ w0 ^ w2 ^ (0x9E3779B9 ^ (72 + 3)));
+    tt = w3 ^ w6 ^ w0 ^ w2 ^ (0x9E3779B9 ^ (72 + 3));
     w3 = tt.rotate_left(11);
     r0 = w0;
     r1 = w1;
@@ -1274,13 +1273,13 @@ fn key_setup(key : &[u8], subkeys : &mut[u32; 100]) {
     subkeys[i] = r0; i+=1;
     subkeys[i] = r3; i+=1;
     subkeys[i] = r1; i+=1;
-    tt =  (w4 ^ w7 ^ w1 ^ w3 ^ (0x9E3779B9 ^ (76)));
+    tt = w4 ^ w7 ^ w1 ^ w3 ^ (0x9E3779B9 ^ (76));
     w4 = tt.rotate_left(11);
-    tt =  (w5 ^ w0 ^ w2 ^ w4 ^ (0x9E3779B9 ^ (76 + 1)));
+    tt = w5 ^ w0 ^ w2 ^ w4 ^ (0x9E3779B9 ^ (76 + 1));
     w5 = tt.rotate_left(11);
-    tt =  (w6 ^ w1 ^ w3 ^ w5 ^ (0x9E3779B9 ^ (76 + 2)));
+    tt = w6 ^ w1 ^ w3 ^ w5 ^ (0x9E3779B9 ^ (76 + 2));
     w6 = tt.rotate_left(11);
-    tt =  (w7 ^ w2 ^ w4 ^ w6 ^ (0x9E3779B9 ^ (76 + 3)));
+    tt = w7 ^ w2 ^ w4 ^ w6 ^ (0x9E3779B9 ^ (76 + 3));
     w7 = tt.rotate_left(11);
     r0 = w4;
     r1 = w5;
@@ -1308,13 +1307,13 @@ fn key_setup(key : &[u8], subkeys : &mut[u32; 100]) {
     subkeys[i] = r4; i+=1;
     subkeys[i] = r2; i+=1;
     subkeys[i] = r0; i+=1;
-    tt =  (w0 ^ w3 ^ w5 ^ w7 ^ (0x9E3779B9 ^ (80)));
+    tt = w0 ^ w3 ^ w5 ^ w7 ^ (0x9E3779B9 ^ (80));
     w0 = tt.rotate_left(11);
-    tt =  (w1 ^ w4 ^ w6 ^ w0 ^ (0x9E3779B9 ^ (80 + 1)));
+    tt = w1 ^ w4 ^ w6 ^ w0 ^ (0x9E3779B9 ^ (80 + 1));
     w1 = tt.rotate_left(11);
-    tt =  (w2 ^ w5 ^ w7 ^ w1 ^ (0x9E3779B9 ^ (80 + 2)));
+    tt = w2 ^ w5 ^ w7 ^ w1 ^ (0x9E3779B9 ^ (80 + 2));
     w2 = tt.rotate_left(11);
-    tt =  (w3 ^ w6 ^ w0 ^ w2 ^ (0x9E3779B9 ^ (80 + 3)));
+    tt = w3 ^ w6 ^ w0 ^ w2 ^ (0x9E3779B9 ^ (80 + 3));
     w3 = tt.rotate_left(11);
     r0 = w0;
     r1 = w1;
@@ -1344,13 +1343,13 @@ fn key_setup(key : &[u8], subkeys : &mut[u32; 100]) {
     subkeys[i] = r3; i+=1;
     subkeys[i] = r1; i+=1;
     subkeys[i] = r0; i+=1;
-    tt =  (w4 ^ w7 ^ w1 ^ w3 ^ (0x9E3779B9 ^ (84)));
+    tt = w4 ^ w7 ^ w1 ^ w3 ^ (0x9E3779B9 ^ (84));
     w4 = tt.rotate_left(11);
-    tt =  (w5 ^ w0 ^ w2 ^ w4 ^ (0x9E3779B9 ^ (84 + 1)));
+    tt = w5 ^ w0 ^ w2 ^ w4 ^ (0x9E3779B9 ^ (84 + 1));
     w5 = tt.rotate_left(11);
-    tt =  (w6 ^ w1 ^ w3 ^ w5 ^ (0x9E3779B9 ^ (84 + 2)));
+    tt = w6 ^ w1 ^ w3 ^ w5 ^ (0x9E3779B9 ^ (84 + 2));
     w6 = tt.rotate_left(11);
-    tt =  (w7 ^ w2 ^ w4 ^ w6 ^ (0x9E3779B9 ^ (84 + 3)));
+    tt = w7 ^ w2 ^ w4 ^ w6 ^ (0x9E3779B9 ^ (84 + 3));
     w7 = tt.rotate_left(11);
     r0 = w4;
     r1 = w5;
@@ -1378,13 +1377,13 @@ fn key_setup(key : &[u8], subkeys : &mut[u32; 100]) {
     subkeys[i] = r1; i+=1;
     subkeys[i] = r4; i+=1;
     subkeys[i] = r2; i+=1;
-    tt =  (w0 ^ w3 ^ w5 ^ w7 ^ (0x9E3779B9 ^ (88)));
+    tt = w0 ^ w3 ^ w5 ^ w7 ^ (0x9E3779B9 ^ (88));
     w0 = tt.rotate_left(11);
-    tt =  (w1 ^ w4 ^ w6 ^ w0 ^ (0x9E3779B9 ^ (88 + 1)));
+    tt = w1 ^ w4 ^ w6 ^ w0 ^ (0x9E3779B9 ^ (88 + 1));
     w1 = tt.rotate_left(11);
-    tt =  (w2 ^ w5 ^ w7 ^ w1 ^ (0x9E3779B9 ^ (88 + 2)));
+    tt = w2 ^ w5 ^ w7 ^ w1 ^ (0x9E3779B9 ^ (88 + 2));
     w2 = tt.rotate_left(11);
-    tt =  (w3 ^ w6 ^ w0 ^ w2 ^ (0x9E3779B9 ^ (88 + 3)));
+    tt = w3 ^ w6 ^ w0 ^ w2 ^ (0x9E3779B9 ^ (88 + 3));
     w3 = tt.rotate_left(11);
     r0 = w0;
     r1 = w1;
@@ -1413,13 +1412,13 @@ fn key_setup(key : &[u8], subkeys : &mut[u32; 100]) {
     subkeys[i] = r3; i+=1;
     subkeys[i] = r0; i+=1;
     subkeys[i] = r2; i+=1;
-    tt =  (w4 ^ w7 ^ w1 ^ w3 ^ (0x9E3779B9 ^ (92)));
+    tt = w4 ^ w7 ^ w1 ^ w3 ^ (0x9E3779B9 ^ (92));
     w4 = tt.rotate_left(11);
-    tt =  (w5 ^ w0 ^ w2 ^ w4 ^ (0x9E3779B9 ^ (92 + 1)));
+    tt = w5 ^ w0 ^ w2 ^ w4 ^ (0x9E3779B9 ^ (92 + 1));
     w5 = tt.rotate_left(11);
-    tt =  (w6 ^ w1 ^ w3 ^ w5 ^ (0x9E3779B9 ^ (92 + 2)));
+    tt = w6 ^ w1 ^ w3 ^ w5 ^ (0x9E3779B9 ^ (92 + 2));
     w6 = tt.rotate_left(11);
-    tt =  (w7 ^ w2 ^ w4 ^ w6 ^ (0x9E3779B9 ^ (92 + 3)));
+    tt = w7 ^ w2 ^ w4 ^ w6 ^ (0x9E3779B9 ^ (92 + 3));
     w7 = tt.rotate_left(11);
     r0 = w4;
     r1 = w5;
@@ -1449,13 +1448,13 @@ fn key_setup(key : &[u8], subkeys : &mut[u32; 100]) {
     subkeys[i] = r4; i+=1;
     subkeys[i] = r0; i+=1;
     subkeys[i] = r3; i+=1;
-    tt =  (w0 ^ w3 ^ w5 ^ w7 ^ (0x9E3779B9 ^ (96)));
+    tt = w0 ^ w3 ^ w5 ^ w7 ^ (0x9E3779B9 ^ (96));
     w0 = tt.rotate_left(11);
-    tt =  (w1 ^ w4 ^ w6 ^ w0 ^ (0x9E3779B9 ^ (96 + 1)));
+    tt = w1 ^ w4 ^ w6 ^ w0 ^ (0x9E3779B9 ^ (96 + 1));
     w1 = tt.rotate_left(11);
-    tt =  (w2 ^ w5 ^ w7 ^ w1 ^ (0x9E3779B9 ^ (96 + 2)));
+    tt = w2 ^ w5 ^ w7 ^ w1 ^ (0x9E3779B9 ^ (96 + 2));
     w2 = tt.rotate_left(11);
-    tt =  (w3 ^ w6 ^ w0 ^ w2 ^ (0x9E3779B9 ^ (96 + 3)));
+    tt = w3 ^ w6 ^ w0 ^ w2 ^ (0x9E3779B9 ^ (96 + 3));
     w3 = tt.rotate_left(11);
     r0 = w0;
     r1 = w1;
@@ -2331,7 +2330,7 @@ impl Decryptor for Sosemanuk {
 mod test {
     use sosemanuk::Sosemanuk;
     use symmetriccipher::SynchronousStreamCipher;
-    use serialize::hex::{FromHex, ToHex};
+    use serialize::hex::{FromHex};
 
     // Vectors from http://www.ecrypt.eu.org/stream/svn/viewcvs.cgi/ecrypt/trunk/submissions/sosemanuk/unverified.test-vectors?rev=108&view=markup
 


### PR DESCRIPTION
Apologies, there was a error in my pull request for adding the SOSEMANUK cipher that didn't get caught due to the whole problem with the rust nightly binary. I thought I'd tested the latest test vectors that I added but it turns out I didn't, and there was a slight error (declared incorrect size for array that caused test to fail).

This new pull request is for adding the HC-128 stream cipher, and fixing the SOSEMANUK problem. I couldn't put it in two different pull requests (as I'd have liked to for tidiness), because they share a dependency on a u32-vector writing function that I added.
The SOSEMANUK cipher now writes its s-box output via this vector method, and is about 40 MB/s better for doing do.

The HC-128 cipher is amazingly fast.
Here's an output from cargo bench:

test hc128::bench::hc128_10 ... bench: 19 ns/iter (+/- 4) = 526 MB/s
test hc128::bench::hc128_1k ... bench: 1381 ns/iter (+/- 419) = 741 MB/s
test hc128::bench::hc128_64k ... bench: 87997 ns/iter (+/- 22266) = 744 MB/s
test sosemanuk::bench::sosemanuk_10 ... bench: 35 ns/iter (+/- 7) = 285 MB/s
test sosemanuk::bench::sosemanuk_1k ... bench: 3127 ns/iter (+/- 879) = 327 MB/s
test sosemanuk::bench::sosemanuk_64k ... bench: 202977 ns/iter (+/- 19874) = 322 MB/s

and Salsa20 for comparison:
test salsa20::bench::salsa20_10 ... bench: 36 ns/iter (+/- 24) = 277 MB/s
test salsa20::bench::salsa20_1k ... bench: 2117 ns/iter (+/- 363) = 483 MB/s
test salsa20::bench::salsa20_64k ... bench: 134849 ns/iter (+/- 13232) = 485 MB/s

This makes HC-128 the fastest cipher implemented so far (apart from AES-NI, which has a bit of an unfair advantage) by a good margin. A part of this may be the extra logic I added in the process() function in the SynchronousStreamCipher impl for processing input blockwise rather than bytewise. This approach could easily be moved to other ciphers... I just haven't done it yet.