### PR TITLE
Update rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-crypto"
-version = "0.2.19"
+version = "0.2.20"
 authors = ["The Rust-Crypto Project Developers"]
 license = "MIT/Apache-2.0"
 homepage = "https://github.com/DaGenix/rust-crypto/"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,6 @@
 #![feature(core)]
 #![feature(io)]
 #![feature(simd)]
-#![feature(old_io)]
 #![cfg_attr(test, feature(test))]
 
 extern crate rand;

--- a/src/pbkdf2.rs
+++ b/src/pbkdf2.rs
@@ -10,7 +10,7 @@
  */
 
 use std::iter::repeat;
-use std::old_io::IoResult;
+use std::io;
 use std::num::Int;
 use std::slice::bytes::copy_memory;
 
@@ -130,7 +130,7 @@ pub fn pbkdf2<M: Mac>(mac: &mut M, salt: &[u8], c: u32, output: &mut [u8]) {
  * * c - The iteration count
  *
  */
-pub fn pbkdf2_simple(password: &str, c: u32) -> IoResult<String> {
+pub fn pbkdf2_simple(password: &str, c: u32) -> io::Result<String> {
     let mut rng = try!(OsRng::new());
 
     // 128-bit salt

--- a/src/scrypt.rs
+++ b/src/scrypt.rs
@@ -13,7 +13,7 @@
  */
 
 use std::iter::repeat;
-use std::old_io::IoResult;
+use std::io;
 use std::num::{Int, ToPrimitive};
 use std::mem::size_of;
 use std::slice::bytes::copy_memory;
@@ -268,7 +268,7 @@ pub fn scrypt(password: &[u8], salt: &[u8], params: &ScryptParams, output: &mut 
  * * params - The ScryptParams to use
  *
  */
-pub fn scrypt_simple(password: &str, params: &ScryptParams) -> IoResult<String> {
+pub fn scrypt_simple(password: &str, params: &ScryptParams) -> io::Result<String> {
     let mut rng = try!(OsRng::new());
 
     // 128-bit salt


### PR DESCRIPTION
The rand module was moved from stdlib to a crate. May still not compile always, due to this bug: https://github.com/rust-lang/rust/issues/23037. `cargo build --release` and `cargo test` do work for me, though.