### PR TITLE
Fix problems resulting from Rust now checking for overflow / underflow

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,13 +12,8 @@ readme = "README.md"
 [lib]
 name = "crypto"
 
-[profile.dev]
-opt-level = 2
-debug = false
-
 [profile.test]
 opt-level = 2
-debug = false
 
 [dependencies]
 time = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-crypto"
-version = "0.2.22"
+version = "0.2.23"
 authors = ["The Rust-Crypto Project Developers"]
 license = "MIT/Apache-2.0"
 homepage = "https://github.com/DaGenix/rust-crypto/"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,6 @@ readme = "README.md"
 [lib]
 name = "crypto"
 
-[profile.test]
-opt-level = 2
-
 [dependencies]
 time = "*"
 rand = "*"

--- a/src/blake2b.rs
+++ b/src/blake2b.rs
@@ -69,13 +69,13 @@ struct Blake2bParam {
 }
 
 macro_rules! G( ($r:expr, $i:expr, $a:expr, $b:expr, $c:expr, $d:expr, $m:expr) => ({
-    $a = $a + $b + $m[SIGMA[$r][2*$i+0]];
+    $a = $a.wrapping_add($b).wrapping_add($m[SIGMA[$r][2*$i+0]]);
     $d = ($d ^ $a).rotate_right(32);
-    $c = $c + $d;
+    $c = $c.wrapping_add($d);
     $b = ($b ^ $c).rotate_right(24);
-    $a = $a + $b + $m[SIGMA[$r][2*$i+1]];
+    $a = $a.wrapping_add($b).wrapping_add($m[SIGMA[$r][2*$i+1]]);
     $d = ($d ^ $a).rotate_right(16);
-    $c = $c + $d;
+    $c = $c .wrapping_add($d);
     $b = ($b ^ $c).rotate_right(63);
 }));
 

--- a/src/blockmodes.rs
+++ b/src/blockmodes.rs
@@ -664,7 +664,7 @@ impl <T: BlockDecryptor, X: PaddingProcessor> Decryptor for CbcDecryptor<T, X> {
 fn add_ctr(ctr: &mut [u8], mut ammount: u8) {
     for i in ctr.iter_mut().rev() {
         let prev = *i;
-        *i += ammount;
+        *i = i.wrapping_add(ammount);
         if *i >= prev {
             break;
         }

--- a/src/blowfish.rs
+++ b/src/blowfish.rs
@@ -275,7 +275,7 @@ impl Blowfish {
     }
 
     fn round_function(&self, x: u32) -> u32 {
-        ((self.s[0][(x >> 24) as usize] + self.s[1][((x >> 16) & 0xff) as usize]) ^ self.s[2][((x >> 8) & 0xff) as usize]) + self.s[3][(x & 0xff) as usize]
+        ((self.s[0][(x >> 24) as usize].wrapping_add(self.s[1][((x >> 16) & 0xff) as usize])) ^ self.s[2][((x >> 8) & 0xff) as usize]).wrapping_add(self.s[3][(x & 0xff) as usize])
     }
 
     // Public for bcrypt.

--- a/src/cryptoutil.rs
+++ b/src/cryptoutil.rs
@@ -309,7 +309,7 @@ pub fn add_bytes_to_bits_tuple
                 // run in practice. This is the reason that this function requires that the type T
                 // be UnsignedInt - overflow is not defined for Signed types. This function could
                 // be implemented for signed types as well if that were needed.
-                Some(y) => return (y, low + new_low_bits),
+                Some(y) => return (y, low.wrapping_add(new_low_bits)),
                 None => panic!("Numeric overflow occured.")
             }
         }

--- a/src/curve25519.rs
+++ b/src/curve25519.rs
@@ -1398,7 +1398,7 @@ impl Sub<GePrecomp> for GeP3 {
 fn equal(b: u8, c: u8) -> i32 {
     let x = b ^ c; /* 0: yes; 1..255: no */
     let mut y = x as u32; /* 0: yes; 1..255: no */
-    y -= 1; /* 4294967295: yes; 0..254: no */
+    y = y.wrapping_sub(1); /* 4294967295: yes; 0..254: no */
     y >>= 31; /* 1: yes; 0: no */
     y as i32
 }

--- a/src/fortuna.rs
+++ b/src/fortuna.rs
@@ -88,7 +88,7 @@ impl FortunaGenerator {
     /// Increments the counter in place
     fn increment_counter(&mut self) {
         for i in (0..self.ctr.len()) {
-            self.ctr[i] += 1;
+            self.ctr[i] = self.ctr[i].wrapping_add(1);
             // As soon as we don't carry, stop
             if self.ctr[i] != 0 {
                 break;

--- a/src/hc128.rs
+++ b/src/hc128.rs
@@ -52,7 +52,7 @@ impl Hc128 {
         }
 
         for i in range(16, 1280) {
-            w[i] = (f2(w[i - 2]) + w[i - 7] + f1(w[i - 15]) + w[i - 16] + (i as u32)) as u32;
+            w[i] = (f2(w[i - 2]).wrapping_add(w[i - 7]).wrapping_add(f1(w[i - 15])).wrapping_add(w[i - 16]).wrapping_add(i as u32)) as u32;
         }
 
         // Copy contents of w into p and q
@@ -75,19 +75,19 @@ impl Hc128 {
         let j : usize = self.cnt & 0x1FF;
 
         // Precompute resources
-        let dim_j3 : usize = (j - 3) & 0x1FF;
-        let dim_j10 : usize = (j - 10) & 0x1FF;
-        let dim_j511 : usize = (j - 511) & 0x1FF;
-        let dim_j12 : usize = (j - 12) & 0x1FF;
+        let dim_j3 : usize = (j.wrapping_sub(3)) & 0x1FF;
+        let dim_j10 : usize = (j.wrapping_sub(10)) & 0x1FF;
+        let dim_j511 : usize = (j.wrapping_sub(511)) & 0x1FF;
+        let dim_j12 : usize = (j.wrapping_sub(12)) & 0x1FF;
 
         let mut ret : u32;
 
         if self.cnt < 512 {
-            self.p[j] += (self.p[dim_j3].rotate_right(10) ^ self.p[dim_j511].rotate_right(23)) + self.p[dim_j10].rotate_right(8);
-            ret = (self.q[(self.p[dim_j12] & 0xFF) as usize] + self.q[(((self.p[dim_j12] >> 16) & 0xFF) + 256) as usize]) ^ self.p[j];
+            self.p[j] = self.p[j].wrapping_add(self.p[dim_j3].rotate_right(10) ^ self.p[dim_j511].rotate_right(23)).wrapping_add(self.p[dim_j10].rotate_right(8));
+            ret = (self.q[(self.p[dim_j12] & 0xFF) as usize].wrapping_add(self.q[(((self.p[dim_j12] >> 16) & 0xFF) + 256) as usize])) ^ self.p[j];
         } else {
-            self.q[j] += (self.q[dim_j3].rotate_left(10) ^ self.q[dim_j511].rotate_left(23)) + self.q[dim_j10].rotate_left(8);
-            ret = (self.p[(self.q[dim_j12] & 0xFF) as usize] + self.p[(((self.q[dim_j12] >> 16) & 0xFF) + 256) as usize]) ^ self.q[j];
+            self.q[j] = self.q[j].wrapping_add(self.q[dim_j3].rotate_left(10) ^ self.q[dim_j511].rotate_left(23)).wrapping_add(self.q[dim_j10].rotate_left(8));
+            ret = (self.p[(self.q[dim_j12] & 0xFF) as usize].wrapping_add(self.p[(((self.q[dim_j12] >> 16) & 0xFF) + 256) as usize])) ^ self.q[j];
         }
 
         self.cnt = (self.cnt + 1) & 0x3FF;    

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,7 @@ pub mod salsa20;
 pub mod scrypt;
 pub mod sha1;
 pub mod sha2;
+mod simd;
 pub mod sosemanuk;
 pub mod symmetriccipher;
 pub mod util;

--- a/src/md5.rs
+++ b/src/md5.rs
@@ -58,19 +58,19 @@ impl Md5State {
         }
 
         fn op_f(w: u32, x: u32, y: u32, z: u32, m: u32, s: u32) -> u32 {
-            (w + f(x, y, z) + m).rotate_left(s) + x
+            w.wrapping_add(f(x, y, z)).wrapping_add(m).rotate_left(s).wrapping_add(x)
         }
 
         fn op_g(w: u32, x: u32, y: u32, z: u32, m: u32, s: u32) -> u32 {
-            (w + g(x, y, z) + m).rotate_left(s) + x
+            w.wrapping_add(g(x, y, z)).wrapping_add(m).rotate_left(s).wrapping_add(x)
         }
 
         fn op_h(w: u32, x: u32, y: u32, z: u32, m: u32, s: u32) -> u32 {
-            (w + h(x, y, z) + m).rotate_left(s) + x
+            w.wrapping_add(h(x, y, z)).wrapping_add(m).rotate_left(s).wrapping_add(x)
         }
 
         fn op_i(w: u32, x: u32, y: u32, z: u32, m: u32, s: u32) -> u32 {
-            (w + i(x, y, z) + m).rotate_left(s) + x
+            w.wrapping_add(i(x, y, z)).wrapping_add(m).rotate_left(s).wrapping_add(x)
         }
 
         let mut a = self.s0;
@@ -84,46 +84,46 @@ impl Md5State {
 
         // round 1
         for i in range_step(0, 16, 4) {
-            a = op_f(a, b, c, d, data[i] + C1[i], 7);
-            d = op_f(d, a, b, c, data[i + 1] + C1[i + 1], 12);
-            c = op_f(c, d, a, b, data[i + 2] + C1[i + 2], 17);
-            b = op_f(b, c, d, a, data[i + 3] + C1[i + 3], 22);
+            a = op_f(a, b, c, d, data[i].wrapping_add(C1[i]), 7);
+            d = op_f(d, a, b, c, data[i + 1].wrapping_add(C1[i + 1]), 12);
+            c = op_f(c, d, a, b, data[i + 2].wrapping_add(C1[i + 2]), 17);
+            b = op_f(b, c, d, a, data[i + 3].wrapping_add(C1[i + 3]), 22);
         }
 
         // round 2
         let mut t = 1;
         for i in range_step(0, 16, 4) {
-            a = op_g(a, b, c, d, data[t & 0x0f] + C2[i], 5);
-            d = op_g(d, a, b, c, data[(t + 5) & 0x0f] + C2[i + 1], 9);
-            c = op_g(c, d, a, b, data[(t + 10) & 0x0f] + C2[i + 2], 14);
-            b = op_g(b, c, d, a, data[(t + 15) & 0x0f] + C2[i + 3], 20);
+            a = op_g(a, b, c, d, data[t & 0x0f].wrapping_add(C2[i]), 5);
+            d = op_g(d, a, b, c, data[(t + 5) & 0x0f].wrapping_add(C2[i + 1]), 9);
+            c = op_g(c, d, a, b, data[(t + 10) & 0x0f].wrapping_add(C2[i + 2]), 14);
+            b = op_g(b, c, d, a, data[(t + 15) & 0x0f].wrapping_add(C2[i + 3]), 20);
             t += 20;
         }
 
         // round 3
         t = 5;
         for i in range_step(0, 16, 4) {
-            a = op_h(a, b, c, d, data[t & 0x0f] + C3[i], 4);
-            d = op_h(d, a, b, c, data[(t + 3) & 0x0f] + C3[i + 1], 11);
-            c = op_h(c, d, a, b, data[(t + 6) & 0x0f] + C3[i + 2], 16);
-            b = op_h(b, c, d, a, data[(t + 9) & 0x0f] + C3[i + 3], 23);
+            a = op_h(a, b, c, d, data[t & 0x0f].wrapping_add(C3[i]), 4);
+            d = op_h(d, a, b, c, data[(t + 3) & 0x0f].wrapping_add(C3[i + 1]), 11);
+            c = op_h(c, d, a, b, data[(t + 6) & 0x0f].wrapping_add(C3[i + 2]), 16);
+            b = op_h(b, c, d, a, data[(t + 9) & 0x0f].wrapping_add(C3[i + 3]), 23);
             t += 12;
         }
 
         // round 4
         t = 0;
         for i in range_step(0, 16, 4) {
-            a = op_i(a, b, c, d, data[t & 0x0f] + C4[i], 6);
-            d = op_i(d, a, b, c, data[(t + 7) & 0x0f] + C4[i + 1], 10);
-            c = op_i(c, d, a, b, data[(t + 14) & 0x0f] + C4[i + 2], 15);
-            b = op_i(b, c, d, a, data[(t + 21) & 0x0f] + C4[i + 3], 21);
+            a = op_i(a, b, c, d, data[t & 0x0f].wrapping_add(C4[i]), 6);
+            d = op_i(d, a, b, c, data[(t + 7) & 0x0f].wrapping_add(C4[i + 1]), 10);
+            c = op_i(c, d, a, b, data[(t + 14) & 0x0f].wrapping_add(C4[i + 2]), 15);
+            b = op_i(b, c, d, a, data[(t + 21) & 0x0f].wrapping_add(C4[i + 3]), 21);
             t += 28;
         }
 
-        self.s0 += a;
-        self.s1 += b;
-        self.s2 += c;
-        self.s3 += d;
+        self.s0 = self.s0.wrapping_add(a);
+        self.s1 = self.s1.wrapping_add(b);
+        self.s2 = self.s2.wrapping_add(c);
+        self.s3 = self.s3.wrapping_add(d);
     }
 }
 

--- a/src/poly1305.rs
+++ b/src/poly1305.rs
@@ -120,14 +120,14 @@ impl Poly1305 {
         h1 +=     c;
 
         // compute h + -p
-        let mut g0 = h0 + 5; c = g0 >> 26; g0 &= 0x3ffffff;
-        let mut g1 = h1 + c; c = g1 >> 26; g1 &= 0x3ffffff;
-        let mut g2 = h2 + c; c = g2 >> 26; g2 &= 0x3ffffff;
-        let mut g3 = h3 + c; c = g3 >> 26; g3 &= 0x3ffffff;
-        let mut g4 = h4 + c - (1 << 26);
+        let mut g0 = h0.wrapping_add(5); c = g0 >> 26; g0 &= 0x3ffffff;
+        let mut g1 = h1.wrapping_add(c); c = g1 >> 26; g1 &= 0x3ffffff;
+        let mut g2 = h2.wrapping_add(c); c = g2 >> 26; g2 &= 0x3ffffff;
+        let mut g3 = h3.wrapping_add(c); c = g3 >> 26; g3 &= 0x3ffffff;
+        let mut g4 = h4.wrapping_add(c).wrapping_sub(1 << 26);
 
         // select h if h < p, or h + -p if h >= p
-        let mut mask = (g4 >> (32 - 1)) - 1;
+        let mut mask = (g4 >> (32 - 1)).wrapping_sub(1);
         g0 &= mask;
         g1 &= mask;
         g2 &= mask;

--- a/src/rc4.rs
+++ b/src/rc4.rs
@@ -29,16 +29,16 @@ impl Rc4 {
         }
         let mut j: u8 = 0;
         for i in (0..256) {
-            j = j + rc4.state[i] + key[i % key.len()];
+            j = j.wrapping_add(rc4.state[i]).wrapping_add(key[i % key.len()]);
             rc4.state.swap(i, j as usize);
         }
         rc4
     }
     fn next(&mut self) -> u8 {
-        self.i = self.i + 1; // we want this to wrap after 255
-        self.j = self.j + self.state[self.i as usize]; // we want this to wrap after 255
+        self.i = self.i.wrapping_add(1);
+        self.j = self.j.wrapping_add(self.state[self.i as usize]);
         self.state.swap(self.i as usize, self.j as usize);
-        let k = self.state[(self.state[self.i as usize] + self.state[self.j as usize]) as usize];
+        let k = self.state[(self.state[self.i as usize].wrapping_add(self.state[self.j as usize])) as usize];
         k
     }
 }

--- a/src/ripemd160.rs
+++ b/src/ripemd160.rs
@@ -47,8 +47,8 @@ fn circular_shift(bits: u32, word: u32) -> u32 {
 macro_rules! round(
     ($a:expr, $b:expr, $c:expr, $d:expr, $e:expr,
      $x:expr, $bits:expr, $add:expr, $round:expr) => ({
-        $a += $round + $x + $add;
-        $a = circular_shift($bits, $a) + $e;
+        $a = $a.wrapping_add($round).wrapping_add($x).wrapping_add($add);
+        $a = circular_shift($bits, $a).wrapping_add($e);
         $c = circular_shift(10, $c);
     });
 );
@@ -135,11 +135,11 @@ macro_rules! process_block(
                   bbb[$pf1] ^ bbb[$pf2] ^ bbb[$pf3]); )*
 
         // Combine results
-        bbb[3] += $h[1] + bb[2];
-        $h[1]   = $h[2] + bb[3] + bbb[4];
-        $h[2]   = $h[3] + bb[4] + bbb[0];
-        $h[3]   = $h[4] + bb[0] + bbb[1];
-        $h[4]   = $h[0] + bb[1] + bbb[2];
+        bbb[3] = bbb[3].wrapping_add($h[1]).wrapping_add(bb[2]);
+        $h[1]   = $h[2].wrapping_add(bb[3]).wrapping_add(bbb[4]);
+        $h[2]   = $h[3].wrapping_add(bb[4]).wrapping_add(bbb[0]);
+        $h[3]   = $h[4].wrapping_add(bb[0]).wrapping_add(bbb[1]);
+        $h[4]   = $h[0].wrapping_add(bb[1]).wrapping_add(bbb[2]);
         $h[0]   =                 bbb[3];
     });
 );

--- a/src/scrypt.rs
+++ b/src/scrypt.rs
@@ -38,7 +38,7 @@ fn salsa20_8(input: &[u8], output: &mut [u8]) {
 
     macro_rules! run_round (
         ($($set_idx:expr, $idx_a:expr, $idx_b:expr, $rot:expr);*) => { {
-            $( x[$set_idx] ^= (x[$idx_a] + x[$idx_b]).rotate_left($rot); )*
+            $( x[$set_idx] ^= x[$idx_a].wrapping_add(x[$idx_b]).rotate_left($rot); )*
         } }
     );
 
@@ -82,7 +82,7 @@ fn salsa20_8(input: &[u8], output: &mut [u8]) {
     for i in (0..16) {
         write_u32_le(
             &mut output[i * 4..(i + 1) * 4],
-            x[i] + read_u32_le(&input[i * 4..(i + 1) * 4]));
+            x[i].wrapping_add(read_u32_le(&input[i * 4..(i + 1) * 4])));
     }
 }
 

--- a/src/sha1.rs
+++ b/src/sha1.rs
@@ -83,7 +83,7 @@ pub fn sha1_first(w0: u32x4) -> u32 {
 #[inline]
 pub fn sha1_first_add(e: u32, w0: u32x4) -> u32x4 {
     let u32x4(a, b, c, d) = w0;
-    u32x4(e + a, b, c, d)
+    u32x4(e.wrapping_add(a), b, c, d)
 }
 
 /// Emulates `llvm.x86.sha1msg1` intrinsic.
@@ -144,10 +144,17 @@ fn sha1rnds4c(abcd: u32x4, msg: u32x4) -> u32x4 {
         ($a:expr, $b:expr, $c:expr) => (($c ^ ($a & ($b ^ $c))))
     } // Choose, MD5F, SHA1C
 
-    e += a.rotate_left(5) + bool3ary_202!(b, c, d) + t; b = b.rotate_left(30);
-    d += e.rotate_left(5) + bool3ary_202!(a, b, c) + u; a = a.rotate_left(30);
-    c += d.rotate_left(5) + bool3ary_202!(e, a, b) + v; e = e.rotate_left(30);
-    b += c.rotate_left(5) + bool3ary_202!(d, e, a) + w; d = d.rotate_left(30);
+    e = e.wrapping_add(a.rotate_left(5)).wrapping_add(bool3ary_202!(b, c, d)).wrapping_add(t);
+    b = b.rotate_left(30);
+
+    d = d.wrapping_add(e.rotate_left(5)).wrapping_add(bool3ary_202!(a, b, c)).wrapping_add(u);
+    a = a.rotate_left(30);
+
+    c = c.wrapping_add(d.rotate_left(5)).wrapping_add(bool3ary_202!(e, a, b)).wrapping_add(v);
+    e = e.rotate_left(30);
+
+    b = b.wrapping_add(c.rotate_left(5)).wrapping_add(bool3ary_202!(d, e, a)).wrapping_add(w);
+    d = d.rotate_left(30);
 
     u32x4(b, c, d, e)
 }
@@ -162,10 +169,17 @@ fn sha1rnds4p(abcd: u32x4, msg: u32x4) -> u32x4 {
         ($a:expr, $b:expr, $c:expr) => (($a ^ $b ^ $c))
     } // Parity, XOR, MD5H, SHA1P
 
-    e += a.rotate_left(5) + bool3ary_150!(b, c, d) + t; b = b.rotate_left(30);
-    d += e.rotate_left(5) + bool3ary_150!(a, b, c) + u; a = a.rotate_left(30);
-    c += d.rotate_left(5) + bool3ary_150!(e, a, b) + v; e = e.rotate_left(30);
-    b += c.rotate_left(5) + bool3ary_150!(d, e, a) + w; d = d.rotate_left(30);
+    e = e.wrapping_add(a.rotate_left(5)).wrapping_add(bool3ary_150!(b, c, d)).wrapping_add(t);
+    b = b.rotate_left(30);
+
+    d = d.wrapping_add(e.rotate_left(5)).wrapping_add(bool3ary_150!(a, b, c)).wrapping_add(u);
+    a = a.rotate_left(30);
+
+    c = c.wrapping_add(d.rotate_left(5)).wrapping_add(bool3ary_150!(e, a, b)).wrapping_add(v);
+    e = e.rotate_left(30);
+
+    b = b.wrapping_add(c.rotate_left(5)).wrapping_add(bool3ary_150!(d, e, a)).wrapping_add(w);
+    d = d.rotate_left(30);
 
     u32x4(b, c, d, e)
 }
@@ -180,10 +194,17 @@ fn sha1rnds4m(abcd: u32x4, msg: u32x4) -> u32x4 {
         ($a:expr, $b:expr, $c:expr) => (($a & $b) ^ ($a & $c) ^ ($b & $c))
     } // Majority, SHA1M
 
-    e += a.rotate_left(5) + bool3ary_232!(b, c, d) + t; b = b.rotate_left(30);
-    d += e.rotate_left(5) + bool3ary_232!(a, b, c) + u; a = a.rotate_left(30);
-    c += d.rotate_left(5) + bool3ary_232!(e, a, b) + v; e = e.rotate_left(30);
-    b += c.rotate_left(5) + bool3ary_232!(d, e, a) + w; d = d.rotate_left(30);
+    e = e.wrapping_add(a.rotate_left(5)).wrapping_add(bool3ary_232!(b, c, d)).wrapping_add(t);
+    b = b.rotate_left(30);
+
+    d = d.wrapping_add(e.rotate_left(5)).wrapping_add(bool3ary_232!(a, b, c)).wrapping_add(u);
+    a = a.rotate_left(30);
+
+    c = c.wrapping_add(d.rotate_left(5)).wrapping_add(bool3ary_232!(e, a, b)).wrapping_add(v);
+    e = e.rotate_left(30);
+
+    b = b.wrapping_add(c.rotate_left(5)).wrapping_add(bool3ary_232!(d, e, a)).wrapping_add(w);
+    d = d.rotate_left(30);
 
     u32x4(b, c, d, e)
 }
@@ -270,11 +291,11 @@ pub fn sha1_digest_block_u32(state: &mut [u32; 5], block: &[u32; 16]) {
     let e = sha1_first(h1).rotate_left(30);
     let u32x4(a, b, c, d) = h0;
 
-    state[0] += a;
-    state[1] += b;
-    state[2] += c;
-    state[3] += d;
-    state[4] += e;
+    state[0] = state[0].wrapping_add(a);
+    state[1] = state[1].wrapping_add(b);
+    state[2] = state[2].wrapping_add(c);
+    state[3] = state[3].wrapping_add(d);
+    state[4] = state[4].wrapping_add(e);
 }
 
 /// Process a block with the SHA-1 algorithm. (See more...)

--- a/src/sha1.rs
+++ b/src/sha1.rs
@@ -61,9 +61,9 @@ algorithms, but some, like "parity" is only found in SHA-1.
  */
 
 use std::num::Int;
-use std::simd::u32x4;
 use digest::Digest;
 use cryptoutil::{write_u32_be, read_u32v_be, add_bytes_to_bits, FixedBuffer, FixedBuffer64, StandardPadding};
+use simd::u32x4;
 
 const STATE_LEN: usize = 5;
 const BLOCK_LEN: usize = 16;

--- a/src/sha2.rs
+++ b/src/sha2.rs
@@ -70,13 +70,14 @@ assert_eq!(hex.as_slice(),
 
  */
 
-use std::simd::{u32x4, u64x2};
 use std::num::Int;
 use digest::Digest;
 use cryptoutil::{write_u32_be, read_u32v_be,
                  write_u64_be, read_u64v_be,
                  add_bytes_to_bits, add_bytes_to_bits_tuple,
                  FixedBuffer, FixedBuffer128, FixedBuffer64, StandardPadding};
+
+use simd::{u32x4, u64x2};
 
 const STATE_LEN: usize = 8;
 const BLOCK_LEN: usize = 16;

--- a/src/sha2.rs
+++ b/src/sha2.rs
@@ -120,10 +120,10 @@ fn sha256msg2(v4: u32x4, v3: u32x4) -> u32x4 {
     let u32x4(x3, x2, x1, x0) = v4;
     let u32x4(w15, w14, _, _) = v3;
 
-    let w16 = x0 + sigma1!(w14);
-    let w17 = x1 + sigma1!(w15);
-    let w18 = x2 + sigma1!(w16);
-    let w19 = x3 + sigma1!(w17);
+    let w16 = x0.wrapping_add(sigma1!(w14));
+    let w17 = x1.wrapping_add(sigma1!(w15));
+    let w18 = x2.wrapping_add(sigma1!(w16));
+    let w19 = x3.wrapping_add(sigma1!(w17));
 
     u32x4(w19, w18, w17, w16)
 }
@@ -155,18 +155,18 @@ pub fn sha256_digest_round_x2(cdgh: u32x4, abef: u32x4, wk: u32x4) -> u32x4 {
     let u32x4(c0, d0, g0, h0) = cdgh;
 
     // a round
-    let x0 = big_sigma1!(e0) + bool3ary_202!(e0, f0, g0) + wk0 + h0;
-    let y0 = big_sigma0!(a0) + bool3ary_232!(a0, b0, c0);
+    let x0 = big_sigma1!(e0).wrapping_add(bool3ary_202!(e0, f0, g0)).wrapping_add(wk0).wrapping_add(h0);
+    let y0 = big_sigma0!(a0).wrapping_add(bool3ary_232!(a0, b0, c0));
     let (a1, b1, c1, d1, e1, f1, g1, h1) = (
-        x0 + y0, a0, b0, c0,
-        x0 + d0, e0, f0, g0);
+        x0.wrapping_add(y0), a0, b0, c0,
+        x0.wrapping_add(d0), e0, f0, g0);
 
     // a round
-    let x1 = big_sigma1!(e1) + bool3ary_202!(e1, f1, g1) + wk1 + h1;
-    let y1 = big_sigma0!(a1) + bool3ary_232!(a1, b1, c1);
+    let x1 = big_sigma1!(e1).wrapping_add(bool3ary_202!(e1, f1, g1)).wrapping_add(wk1).wrapping_add(h1);
+    let y1 = big_sigma0!(a1).wrapping_add(bool3ary_232!(a1, b1, c1));
     let (a2, b2, _, _, e2, f2, _, _) = (
-        x1 + y1, a1, b1, c1,
-        x1 + d1, e1, f1, g1);
+        x1.wrapping_add(y1), a1, b1, c1,
+        x1.wrapping_add(d1), e1, f1, g1);
 
     u32x4(a2, b2, e2, f2)
 }
@@ -248,14 +248,14 @@ pub fn sha256_digest_block_u32(state: &mut [u32; 8], block: &[u32; 16]) {
     let u32x4(a, b, e, f) = abef;
     let u32x4(c, d, g, h) = cdgh;
 
-    state[0] += a;
-    state[1] += b;
-    state[2] += c;
-    state[3] += d;
-    state[4] += e;
-    state[5] += f;
-    state[6] += g;
-    state[7] += h;
+    state[0] = state[0].wrapping_add(a);
+    state[1] = state[1].wrapping_add(b);
+    state[2] = state[2].wrapping_add(c);
+    state[3] = state[3].wrapping_add(d);
+    state[4] = state[4].wrapping_add(e);
+    state[5] = state[5].wrapping_add(f);
+    state[6] = state[6].wrapping_add(g);
+    state[7] = state[7].wrapping_add(h);
 }
 
 /// Process a block with the SHA-256 algorithm. (See more...)
@@ -380,8 +380,8 @@ pub fn sha512_schedule_x2(v0: u64x2, v1: u64x2, v4to5: u64x2, v7: u64x2) -> u64x
     let u64x2(w10, w9) 	= v4to5;
     let u64x2(w15, w14) = v7;
 
-    let w16 = sigma1(w14) + w9  + sigma0(w1) + w0;
-    let w17 = sigma1(w15) + w10 + sigma0(w2) + w1;
+    let w16 = sigma1(w14).wrapping_add(w9).wrapping_add(sigma0(w1)).wrapping_add(w0);
+    let w17 = sigma1(w15).wrapping_add(w10).wrapping_add(sigma0(w2)).wrapping_add(w1);
 
     u64x2(w17, w16)
 }
@@ -408,11 +408,11 @@ pub fn sha512_digest_round(ae: u64x2, bf: u64x2, cg: u64x2, dh: u64x2, wk0: u64)
     let u64x2(d0, h0) = dh;
 
     // a round
-    let x0 = big_sigma1!(e0) + bool3ary_202!(e0, f0, g0) + wk0 + h0;
-    let y0 = big_sigma0!(a0) + bool3ary_232!(a0, b0, c0);
+    let x0 = big_sigma1!(e0).wrapping_add(bool3ary_202!(e0, f0, g0)).wrapping_add(wk0).wrapping_add(h0);
+    let y0 = big_sigma0!(a0).wrapping_add(bool3ary_232!(a0, b0, c0));
     let (a1, _, _, _, e1, _, _, _) = (
-        x0 + y0, a0, b0, c0,
-        x0 + d0, e0, f0, g0);
+        x0.wrapping_add(y0), a0, b0, c0,
+        x0.wrapping_add(d0), e0, f0, g0);
 
     u64x2(a1, e1)
 }
@@ -531,14 +531,14 @@ pub fn sha512_digest_block_u64(state: &mut [u64; 8], block: &[u64; 16]) {
     let u64x2(c, g) = cg;
     let u64x2(d, h) = dh;
 
-    state[0] += a;
-    state[1] += b;
-    state[2] += c;
-    state[3] += d;
-    state[4] += e;
-    state[5] += f;
-    state[6] += g;
-    state[7] += h;
+    state[0] = state[0].wrapping_add(a);
+    state[1] = state[1].wrapping_add(b);
+    state[2] = state[2].wrapping_add(c);
+    state[3] = state[3].wrapping_add(d);
+    state[4] = state[4].wrapping_add(e);
+    state[5] = state[5].wrapping_add(f);
+    state[6] = state[6].wrapping_add(g);
+    state[7] = state[7].wrapping_add(h);
 }
 
 /// Process a block with the SHA-512 algorithm. (See more...)

--- a/src/simd.rs
+++ b/src/simd.rs
@@ -1,0 +1,141 @@
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[cfg(not(ndebug))]
+pub use self::fake::*;
+
+#[cfg(ndebug)]
+pub use self::real::*;
+
+pub trait SimdExt {
+    fn simd_eq(self, rhs: Self) -> Self;
+}
+
+#[cfg(not(ndebug))]
+impl SimdExt for fake::u32x4 {
+    fn simd_eq(self, rhs: Self) -> Self {
+        if self == rhs {
+            fake::u32x4(0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff)
+        } else {
+            fake::u32x4(0, 0, 0, 0)
+        }
+    }
+}
+
+#[cfg(ndebug)]
+impl SimdExt for real::u32x4 {
+    fn simd_eq(self, rhs: Self) -> Self {
+        self == rhs
+    }
+}
+
+#[cfg(not(ndebug))]
+mod fake {
+    use std::ops::{Add, BitAnd, BitOr, BitXor, Shl, Shr, Sub};
+
+    #[derive(Copy, PartialEq, Eq)]
+    #[allow(non_camel_case_types)]
+    pub struct u32x4(pub u32, pub u32, pub u32, pub u32);
+
+    impl Add for u32x4 {
+        type Output = u32x4;
+
+        fn add(self, rhs: u32x4) -> u32x4 {
+            u32x4(
+                self.0.wrapping_add(rhs.0),
+                self.1.wrapping_add(rhs.1),
+                self.2.wrapping_add(rhs.2),
+                self.3.wrapping_add(rhs.3))
+        }
+    }
+
+    impl Sub for u32x4 {
+        type Output = u32x4;
+
+        fn sub(self, rhs: u32x4) -> u32x4 {
+            u32x4(
+                self.0.wrapping_sub(rhs.0),
+                self.1.wrapping_sub(rhs.1),
+                self.2.wrapping_sub(rhs.2),
+                self.3.wrapping_sub(rhs.3))
+        }
+    }
+
+    impl BitAnd for u32x4 {
+        type Output = u32x4;
+
+        fn bitand(self, rhs: u32x4) -> u32x4 {
+            u32x4(self.0 & rhs.0, self.1 & rhs.1, self.2 & rhs.2, self.3 & rhs.3)
+        }
+    }
+
+    impl BitOr for u32x4 {
+        type Output = u32x4;
+
+        fn bitor(self, rhs: u32x4) -> u32x4 {
+            u32x4(self.0 | rhs.0, self.1 | rhs.1, self.2 | rhs.2, self.3 | rhs.3)
+        }
+    }
+
+    impl BitXor for u32x4 {
+        type Output = u32x4;
+
+        fn bitxor(self, rhs: u32x4) -> u32x4 {
+            u32x4(self.0 ^ rhs.0, self.1 ^ rhs.1, self.2 ^ rhs.2, self.3 ^ rhs.3)
+        }
+    }
+
+    impl Shl<usize> for u32x4 {
+        type Output = u32x4;
+
+        fn shl(self, amt: usize) -> u32x4 {
+            u32x4(self.0 << amt, self.1 << amt, self.2 << amt, self.3 << amt)
+        }
+    }
+
+    impl Shl<u32x4> for u32x4 {
+        type Output = u32x4;
+
+        fn shl(self, rhs: u32x4) -> u32x4 {
+            u32x4(self.0 << rhs.0, self.1 << rhs.1, self.2 << rhs.2, self.3 << rhs.3)
+        }
+    }
+
+    impl Shr<usize> for u32x4 {
+        type Output = u32x4;
+
+        fn shr(self, amt: usize) -> u32x4 {
+            u32x4(self.0 >> amt, self.1 >> amt, self.2 >> amt, self.3 >> amt)
+        }
+    }
+
+    impl Shr<u32x4> for u32x4 {
+        type Output = u32x4;
+
+        fn shr(self, rhs: u32x4) -> u32x4 {
+            u32x4(self.0 >> rhs.0, self.1 >> rhs.1, self.2 >> rhs.2, self.3 >> rhs.3)
+        }
+    }
+
+    #[derive(Copy)]
+    #[allow(non_camel_case_types)]
+    pub struct u64x2(pub u64, pub u64);
+
+    impl Add for u64x2 {
+        type Output = u64x2;
+
+        fn add(self, rhs: u64x2) -> u64x2 {
+            u64x2(self.0.wrapping_add(rhs.0), self.1.wrapping_add(rhs.1))
+        }
+    }
+}
+
+#[cfg(ndebug)]
+mod real {
+    pub use std::simd::u32x4;
+    pub use std::simd::u64x2;
+}
+

--- a/src/sosemanuk.rs
+++ b/src/sosemanuk.rs
@@ -201,51 +201,51 @@ impl Sosemanuk {
  
         tt = r1;
         //r1 = r2 + (s1 ^ ((r1 & 0x01) != 0 ? s8 : 0));
-        r1 = r2 + (s1 ^ match r1 & 0x01 {
+        r1 = r2.wrapping_add(s1 ^ match r1 & 0x01 {
             0 => 0,
             _ => s8
         });
-        r2 = (tt * 0x54655307).rotate_left(7) as u32;
+        r2 = tt.wrapping_mul(0x54655307).rotate_left(7) as u32;
         v0 = s0;
         s0 = ((s0 << 8) ^ mul_alpha[s0 as usize >> 24])
             ^ ((s3 >> 8) ^ div_alpha[s3 as usize & 0xFF]) ^ s9;
-        f0 = (s9 + r1) ^ r2;
+        f0 = s9.wrapping_add(r1) ^ r2;
  
         tt = r1;
         //r1 = r2 + (s2 ^ ((r1 & 0x01) != 0 ? s9 : 0));
-        r1 = r2 + (s2 ^ match r1 & 0x01 {
+        r1 = r2.wrapping_add(s2 ^ match r1 & 0x01 {
             0 => 0,
             _ => s9
         });
-        r2 = (tt * 0x54655307).rotate_left(7) as u32;
+        r2 = tt.wrapping_mul(0x54655307).rotate_left(7) as u32;
         v1 = s1;
         s1 = ((s1 << 8) ^ mul_alpha[s1 as usize >> 24])
             ^ ((s4 >> 8) ^ div_alpha[s4 as usize & 0xFF]) ^ s0;
-        f1 = (s0 + r1) ^ r2;
+        f1 = s0.wrapping_add(r1) ^ r2;
  
         tt = r1;
         //r1 = r2 + (s3 ^ ((r1 & 0x01) != 0 ? s0 : 0));
-        r1 = r2 + (s3 ^ match r1 & 0x01 {
+        r1 = r2.wrapping_add(s3 ^ match r1 & 0x01 {
             0 => 0,
             _ => s0
         });
-        r2 = (tt * 0x54655307).rotate_left(7) as u32;
+        r2 = tt.wrapping_mul(0x54655307).rotate_left(7) as u32;
         v2 = s2;
         s2 = ((s2 << 8) ^ mul_alpha[s2 as usize >> 24])
             ^ ((s5 >> 8) ^ div_alpha[s5 as usize & 0xFF]) ^ s1;
-        f2 = (s1 + r1) ^ r2;
+        f2 = s1.wrapping_add(r1) ^ r2;
  
         tt = r1;
         //r1 = r2 + (s4 ^ ((r1 & 0x01) != 0 ? s1 : 0));
-        r1 = r2 + (s4 ^ match r1 & 0x01 {
+        r1 = r2.wrapping_add(s4 ^ match r1 & 0x01 {
             0 => 0,
             _ => s1
         });
-        r2 = (tt * 0x54655307).rotate_left(7) as u32;
+        r2 = tt.wrapping_mul(0x54655307).rotate_left(7) as u32;
         v3 = s3;
         s3 = ((s3 << 8) ^ mul_alpha[s3 as usize >> 24])
             ^ ((s6 >> 8) ^ div_alpha[s6 as usize & 0xFF]) ^ s2;
-        f3 = (s2 + r1) ^ r2;
+        f3 = s2.wrapping_add(r1) ^ r2;
  
         /*
          * Apply the third S-box (number 2) on (f3, f2, f1, f0).
@@ -275,51 +275,51 @@ impl Sosemanuk {
 
         tt = r1;
         //r1 = r2 + (s5 ^ ((r1 & 0x01) != 0 ? s2 : 0));
-        r1 = r2 + (s5 ^ match r1 & 0x01 {
+        r1 = r2.wrapping_add(s5 ^ match r1 & 0x01 {
             0 => 0,
             _ => s2
         });
-        r2 = (tt * 0x54655307).rotate_left(7) as u32;
+        r2 = tt.wrapping_mul(0x54655307).rotate_left(7) as u32;
         v0 = s4;
         s4 = ((s4 << 8) ^ mul_alpha[s4 as usize >> 24])
             ^ ((s7 >> 8) ^ div_alpha[s7 as usize & 0xFF]) ^ s3;
-        f0 = (s3 + r1) ^ r2;
+        f0 = s3.wrapping_add(r1) ^ r2;
  
         tt = r1;
         //r1 = r2 + (s6 ^ ((r1 & 0x01) != 0 ? s3 : 0));
-        r1 = r2 + (s6 ^ match r1 & 0x01 {
+        r1 = r2.wrapping_add(s6 ^ match r1 & 0x01 {
             0 => 0,
             _ => s3
         });
-        r2 = (tt * 0x54655307).rotate_left(7) as u32;
+        r2 = tt.wrapping_mul(0x54655307).rotate_left(7) as u32;
         v1 = s5;
         s5 = ((s5 << 8) ^ mul_alpha[s5 as usize >> 24])
             ^ ((s8 >> 8) ^ div_alpha[s8 as usize & 0xFF]) ^ s4;
-        f1 = (s4 + r1) ^ r2;
+        f1 = s4.wrapping_add(r1) ^ r2;
  
         tt = r1;
         //r1 = r2 + (s7 ^ ((r1 & 0x01) != 0 ? s4 : 0));
-        r1 = r2 + (s7 ^ match r1 & 0x01 {
+        r1 = r2.wrapping_add(s7 ^ match r1 & 0x01 {
             0 => 0,
             _ => s4
         });
-        r2 = (tt * 0x54655307).rotate_left(7) as u32;
+        r2 = tt.wrapping_mul(0x54655307).rotate_left(7) as u32;
         v2 = s6;
         s6 = ((s6 << 8) ^ mul_alpha[s6 as usize >> 24])
             ^ ((s9 >> 8) ^ div_alpha[s9 as usize & 0xFF]) ^ s5;
-        f2 = (s5 + r1) ^ r2;
+        f2 = s5.wrapping_add(r1) ^ r2;
  
         tt = r1;
         //r1 = r2 + (s8 ^ ((r1 & 0x01) != 0 ? s5 : 0));
-        r1 = r2 + (s8 ^ match r1 & 0x01 {
+        r1 = r2.wrapping_add(s8 ^ match r1 & 0x01 {
             0 => 0,
             _ => s5
         });
-        r2 = (tt * 0x54655307).rotate_left(7) as u32;
+        r2 = tt.wrapping_mul(0x54655307).rotate_left(7) as u32;
         v3 = s7;
         s7 = ((s7 << 8) ^ mul_alpha[s7 as usize >> 24])
             ^ ((s0 >> 8) ^ div_alpha[s0 as usize & 0xFF]) ^ s6;
-        f3 = (s6 + r1) ^ r2;
+        f3 = s6.wrapping_add(r1) ^ r2;
  
         /*
          * Apply the third S-box (number 2) on (f3, f2, f1, f0).
@@ -349,51 +349,51 @@ impl Sosemanuk {
 
         tt = r1;
         //r1 = r2 + (s9 ^ ((r1 & 0x01) != 0 ? s6 : 0));
-        r1 = r2 + (s9 ^ match r1 & 0x01 {
+        r1 = r2.wrapping_add(s9 ^ match r1 & 0x01 {
             0 => 0,
             _ => s6
         });
-        r2 = (tt * 0x54655307).rotate_left(7) as u32;
+        r2 = tt.wrapping_mul(0x54655307).rotate_left(7) as u32;
         v0 = s8;
         s8 = ((s8 << 8) ^ mul_alpha[s8 as usize >> 24])
             ^ ((s1 >> 8) ^ div_alpha[s1 as usize & 0xFF]) ^ s7;
-        f0 = (s7 + r1) ^ r2;
+        f0 = s7.wrapping_add(r1) ^ r2;
  
         tt = r1;
         //r1 = r2 + (s0 ^ ((r1 & 0x01) != 0 ? s7 : 0));
-        r1 = r2 + (s0 ^ match r1 & 0x01 {
+        r1 = r2.wrapping_add(s0 ^ match r1 & 0x01 {
             0 => 0,
             _ => s7
         });
-        r2 = (tt * 0x54655307).rotate_left(7) as u32;
+        r2 = tt.wrapping_mul(0x54655307).rotate_left(7) as u32;
         v1 = s9;
         s9 = ((s9 << 8) ^ mul_alpha[s9 as usize >> 24])
             ^ ((s2 >> 8) ^ div_alpha[s2 as usize & 0xFF]) ^ s8;
-        f1 = (s8 + r1) ^ r2;
+        f1 = s8.wrapping_add(r1) ^ r2;
  
         tt = r1;
         //r1 = r2 + (s1 ^ ((r1 & 0x01) != 0 ? s8 : 0));
-        r1 = r2 + (s1 ^ match r1 & 0x01 {
+        r1 = r2.wrapping_add(s1 ^ match r1 & 0x01 {
             0 => 0,
             _ => s8
         });
-        r2 = (tt * 0x54655307).rotate_left(7) as u32;
+        r2 = tt.wrapping_mul(0x54655307).rotate_left(7) as u32;
         v2 = s0;
         s0 = ((s0 << 8) ^ mul_alpha[s0 as usize >> 24])
             ^ ((s3 >> 8) ^ div_alpha[s3 as usize & 0xFF]) ^ s9;
-        f2 = (s9 + r1) ^ r2;
+        f2 = s9.wrapping_add(r1) ^ r2;
  
         tt = r1;
         //r1 = r2 + (s2 ^ ((r1 & 0x01) != 0 ? s9 : 0));
-        r1 = r2 + (s2 ^ match r1 & 0x01 {
+        r1 = r2.wrapping_add(s2 ^ match r1 & 0x01 {
             0 => 0,
             _ => s9
         });
-        r2 = (tt * 0x54655307).rotate_left(7) as u32;
+        r2 = tt.wrapping_mul(0x54655307).rotate_left(7) as u32;
         v3 = s1;
         s1 = ((s1 << 8) ^ mul_alpha[s1 as usize >> 24])
             ^ ((s4 >> 8) ^ div_alpha[s4 as usize & 0xFF]) ^ s0;
-        f3 = (s0 + r1) ^ r2;
+        f3 = s0.wrapping_add(r1) ^ r2;
  
         /*
          * Apply the third S-box (number 2) on (f3, f2, f1, f0).
@@ -423,51 +423,51 @@ impl Sosemanuk {
 
         tt = r1;
         //r1 = r2 + (s3 ^ ((r1 & 0x01) != 0 ? s0 : 0));
-        r1 = r2 + (s3 ^ match r1 & 0x01 {
+        r1 = r2.wrapping_add(s3 ^ match r1 & 0x01 {
             0 => 0,
             _ => s0
         });
-        r2 = (tt * 0x54655307).rotate_left(7) as u32;
+        r2 = tt.wrapping_mul(0x54655307).rotate_left(7) as u32;
         v0 = s2;
         s2 = ((s2 << 8) ^ mul_alpha[s2 as usize >> 24])
             ^ ((s5 >> 8) ^ div_alpha[s5 as usize & 0xFF]) ^ s1;
-        f0 = (s1 + r1) ^ r2;
+        f0 = s1.wrapping_add(r1) ^ r2;
  
         tt = r1;
         //r1 = r2 + (s4 ^ ((r1 & 0x01) != 0 ? s1 : 0));
-        r1 = r2 + (s4 ^ match r1 & 0x01 {
+        r1 = r2.wrapping_add(s4 ^ match r1 & 0x01 {
             0 => 0,
             _ => s1
         });
-        r2 = (tt * 0x54655307).rotate_left(7) as u32;
+        r2 = tt.wrapping_mul(0x54655307).rotate_left(7) as u32;
         v1 = s3;
         s3 = ((s3 << 8) ^ mul_alpha[s3 as usize >> 24])
             ^ ((s6 >> 8) ^ div_alpha[s6 as usize & 0xFF]) ^ s2;
-        f1 = (s2 + r1) ^ r2;
+        f1 = s2.wrapping_add(r1) ^ r2;
  
         tt = r1;
         //r1 = r2 + (s5 ^ ((r1 & 0x01) != 0 ? s2 : 0));
-        r1 = r2 + (s5 ^ match r1 & 0x01 {
+        r1 = r2.wrapping_add(s5 ^ match r1 & 0x01 {
             0 => 0,
             _ => s2
         });
-        r2 = (tt * 0x54655307).rotate_left(7) as u32;
+        r2 = tt.wrapping_mul(0x54655307).rotate_left(7) as u32;
         v2 = s4;
         s4 = ((s4 << 8) ^ mul_alpha[s4 as usize >> 24])
             ^ ((s7 >> 8) ^ div_alpha[s7 as usize & 0xFF]) ^ s3;
-        f2 = (s3 + r1) ^ r2;
+        f2 = s3.wrapping_add(r1) ^ r2;
  
         tt = r1;
         //r1 = r2 + (s6 ^ ((r1 & 0x01) != 0 ? s3 : 0));
-        r1 = r2 + (s6 ^ match r1 & 0x01 {
+        r1 = r2.wrapping_add(s6 ^ match r1 & 0x01 {
             0 => 0,
             _ => s3
         });
-        r2 = (tt * 0x54655307).rotate_left(7) as u32;
+        r2 = tt.wrapping_mul(0x54655307).rotate_left(7) as u32;
         v3 = s5;
         s5 = ((s5 << 8) ^ mul_alpha[s5 as usize >> 24])
             ^ ((s8 >> 8) ^ div_alpha[s8 as usize & 0xFF]) ^ s4;
-        f3 = (s4 + r1) ^ r2;
+        f3 = s4.wrapping_add(r1) ^ r2;
  
         /*
          * Apply the third S-box (number 2) on (f3, f2, f1, f0).
@@ -497,51 +497,51 @@ impl Sosemanuk {
  
         tt = r1;
         //r1 = r2 + (s7 ^ ((r1 & 0x01) != 0 ? s4 : 0));
-        r1 = r2 + (s7 ^ match r1 & 0x01 {
+        r1 = r2.wrapping_add(s7 ^ match r1 & 0x01 {
             0 => 0,
             _ => s4
         });
-        r2 = (tt * 0x54655307).rotate_left(7) as u32;
+        r2 = tt.wrapping_mul(0x54655307).rotate_left(7) as u32;
         v0 = s6;
         s6 = ((s6 << 8) ^ mul_alpha[s6 as usize >> 24])
             ^ ((s9 >> 8) ^ div_alpha[s9 as usize & 0xFF]) ^ s5;
-        f0 = (s5 + r1) ^ r2;
+        f0 = s5.wrapping_add(r1) ^ r2;
  
         tt = r1;
         //r1 = r2 + (s8 ^ ((r1 & 0x01) != 0 ? s5 : 0));
-        r1 = r2 + (s8 ^ match r1 & 0x01 {
+        r1 = r2.wrapping_add(s8 ^ match r1 & 0x01 {
             0 => 0,
             _ => s5
         });
-        r2 = (tt * 0x54655307).rotate_left(7) as u32;
+        r2 = tt.wrapping_mul(0x54655307).rotate_left(7) as u32;
         v1 = s7;
         s7 = ((s7 << 8) ^ mul_alpha[s7 as usize >> 24])
             ^ ((s0 >> 8) ^ div_alpha[s0 as usize & 0xFF]) ^ s6;
-        f1 = (s6 + r1) ^ r2;
+        f1 = s6.wrapping_add(r1) ^ r2;
  
         tt = r1;
         //r1 = r2 + (s9 ^ ((r1 & 0x01) != 0 ? s6 : 0));
-        r1 = r2 + (s9 ^ match r1 & 0x01 {
+        r1 = r2.wrapping_add(s9 ^ match r1 & 0x01 {
             0 => 0,
             _ => s6
         });
-        r2 = (tt * 0x54655307).rotate_left(7) as u32;
+        r2 = tt.wrapping_mul(0x54655307).rotate_left(7) as u32;
         v2 = s8;
         s8 = ((s8 << 8) ^ mul_alpha[s8 as usize >> 24])
             ^ ((s1 >> 8) ^ div_alpha[s1 as usize & 0xFF]) ^ s7;
-        f2 = (s7 + r1) ^ r2;
+        f2 = s7.wrapping_add(r1) ^ r2;
  
         tt = r1;
         //r1 = r2 + (s0 ^ ((r1 & 0x01) != 0 ? s7 : 0));
-        r1 = r2 + (s0 ^ match r1 & 0x01 {
+        r1 = r2.wrapping_add(s0 ^ match r1 & 0x01 {
             0 => 0,
             _ => s7
         });
-        r2 = (tt * 0x54655307).rotate_left(7) as u32;
+        r2 = tt.wrapping_mul(0x54655307).rotate_left(7) as u32;
         v3 = s9;
         s9 = ((s9 << 8) ^ mul_alpha[s9 as usize >> 24])
             ^ ( ( s2 >> 8) ^ div_alpha[s2 as usize & 0xFF]) ^ s8;
-        f3 = (s8 + r1) ^ r2;
+        f3 = s8.wrapping_add(r1) ^ r2;
  
         /*
          * Apply the third S-box (number 2) on (f3, f2, f1, f0).


### PR DESCRIPTION
Fix problems resulting from Rust not checking for overflow / underflow:

* Work around a Rust bug with the overflow / underflow checking as it relates to SIMD types - rust-lang/rust#23037. When "ndebug" is NOT defined (ie: overflow checking is on), use a new "fake-SIMD" type that just simulates all of the SIMD operations using regular tuples of integer types. When "ndebug" is defined (ie: overflow checking is off), use the regular SIMD types.

* Replace all addition, subtraction, and multiplication that was causing test failures due to overflowing or underflowing with wrapped_add(), wrapped_sub(), or wrapped_mul() as appropriate.

* Disable optimizations for test builds to help try to make sure that no more overflowing or underflowing operations make it into the code base without using the wrapped_* functions.

Closes #266