### PR TITLE
Replace x.as_mut_ref() by &mut

### DIFF
--- a/src/bcrypt_pbkdf.rs
+++ b/src/bcrypt_pbkdf.rs
@@ -47,13 +47,13 @@ pub fn bcrypt_pbkdf(password: &[u8], salt: &[u8], rounds: u32, output: &mut [u8]
 
     let mut h = Sha512::new();
     h.input(password);
-    h.result(hpass.as_mut_slice());
+    h.result(&mut hpass);
 
     for block in (1..(nblocks+1)) {
         let mut count = [0u8; 4];
         let mut hsalt = [0u8; 64];
         let mut out   = [0u8; 32];
-        write_u32_be(count.as_mut_slice(), block as u32);
+        write_u32_be(&mut count, block as u32);
 
         h.reset();
         h.input(salt);
@@ -276,7 +276,7 @@ mod bench {
         let mut out  = [0u8; 32];
 
         b.iter(|| {
-            bcrypt_pbkdf(&pass, &salt, 5, out.as_mut_slice());
+            bcrypt_pbkdf(&pass, &salt, 5, &mut out);
         });
     }
 }

--- a/src/blake2b.rs
+++ b/src/blake2b.rs
@@ -383,7 +383,7 @@ impl Mac for Blake2b {
      */
     fn result(&mut self) -> MacResult {
         let mut mac: Vec<u8> = repeat(0).take(self.digest_length as usize).collect();
-        self.raw_result(mac.as_mut_slice());
+        self.raw_result(&mut mac);
         MacResult::new_from_owned(mac)
     }
 

--- a/src/blowfish.rs
+++ b/src/blowfish.rs
@@ -314,7 +314,7 @@ impl BlockEncryptor for Blowfish {
         assert!(input.len() == 8);
         assert!(output.len() == 8);
         let mut block = [0u32, 0u32];
-        read_u32v_be(block.as_mut_slice(), input);
+        read_u32v_be(&mut block, input);
         let (l, r) = self.encrypt(block[0], block[1]);
         write_u32_be(&mut output[0..4], l);
         write_u32_be(&mut output[4..8], r);
@@ -330,7 +330,7 @@ impl BlockDecryptor for Blowfish {
         assert!(input.len() == 8);
         assert!(output.len() == 8);
         let mut block = [0u32, 0u32];
-        read_u32v_be(block.as_mut_slice(), input);
+        read_u32v_be(&mut block, input);
         let (l, r) = self.decrypt(block[0], block[1]);
         write_u32_be(&mut output[0..4], l);
         write_u32_be(&mut output[4..8], r);

--- a/src/curve25519.rs
+++ b/src/curve25519.rs
@@ -2168,9 +2168,9 @@ mod tests {
     fn from_to_bytes_preserves() {
         for i in (0..50) {
             let mut e: Vec<u8> = (0u32..32).map(|idx| (idx*(1289+i*761)) as u8).collect();
-            e.as_mut_slice()[0] &= 248;
-            e.as_mut_slice()[31] &= 127;
-            e.as_mut_slice()[31] |= 64;
+            e[0] &= 248;
+            e[31] &= 127;
+            e[31] |= 64;
             let fe = Fe::from_bytes(e.as_ref());
             let e_preserved = fe.to_bytes();
             assert!(e == e_preserved.to_vec());
@@ -2205,9 +2205,9 @@ mod tests {
 
         fn next(&mut self) -> Option<Fe> {
             let mut e: Vec<u8> = (0..32).map(|idx| (idx*(1289+self.which*761)) as u8).collect();
-            e.as_mut_slice()[0] &= 248;
-            e.as_mut_slice()[31] &= 127;
-            e.as_mut_slice()[31] |= 64;
+            e[0] &= 248;
+            e[31] &= 127;
+            e[31] |= 64;
             Some(Fe::from_bytes(e.as_ref()))
         }
     }

--- a/src/digest.rs
+++ b/src/digest.rs
@@ -75,7 +75,7 @@ pub trait Digest {
         use serialize::hex::ToHex;
 
         let mut buf: Vec<u8> = repeat(0).take((self.output_bits()+7)/8).collect();
-        self.result(buf.as_mut_slice());
+        self.result(&mut buf);
         buf[..].to_hex()
     }
 }

--- a/src/ed25519.rs
+++ b/src/ed25519.rs
@@ -9,7 +9,7 @@ pub fn keypair(seed: &[u8]) -> ([u8; 64], [u8; 32]) {
         let mut hash_output: [u8; 64] = [0; 64];
         let mut hasher = Sha512::new();
         hasher.input(seed);
-        hasher.result(hash_output.as_mut_slice());
+        hasher.result(&mut hash_output);
         hash_output[0] &= 248;
         hash_output[31] &= 63;
         hash_output[31] |= 64;
@@ -34,7 +34,7 @@ pub fn signature(message: &[u8], secret_key: &[u8]) -> [u8; 64] {
         let mut hash_output: [u8; 64] = [0; 64];
         let mut hasher = Sha512::new();
         hasher.input(seed);
-        hasher.result(hash_output.as_mut_slice());
+        hasher.result(&mut hash_output);
         hash_output[0] &= 248;
         hash_output[31] &= 63;
         hash_output[31] |= 64;
@@ -46,7 +46,7 @@ pub fn signature(message: &[u8], secret_key: &[u8]) -> [u8; 64] {
         let mut hasher = Sha512::new();
         hasher.input(&az[32..64]);
         hasher.input(message);
-        hasher.result(hash_output.as_mut_slice());
+        hasher.result(&mut hash_output);
         sc_reduce(&mut hash_output[0..64]);
         hash_output
     };
@@ -65,8 +65,8 @@ pub fn signature(message: &[u8], secret_key: &[u8]) -> [u8; 64] {
         hasher.input(signature.as_ref());
         hasher.input(message);
         let mut hram: [u8; 64] = [0; 64];
-        hasher.result(hram.as_mut_slice());
-        sc_reduce(hram.as_mut_slice());
+        hasher.result(&mut hram);
+        sc_reduce(&mut hram);
         sc_muladd(&mut signature[32..64], &hram[0..32], &az[0..32], &nonce[0..32]);
     }
 
@@ -112,8 +112,8 @@ pub fn verify(message: &[u8], public_key: &[u8], signature: &[u8]) -> bool {
     hasher.input(public_key);
     hasher.input(message);
     let mut hash: [u8; 64] = [0; 64];
-    hasher.result(hash.as_mut_slice());
-    sc_reduce(hash.as_mut_slice());
+    hasher.result(&mut hash);
+    sc_reduce(&mut hash);
 
     let r = GeP2::double_scalarmult_vartime(hash.as_ref(), a, &signature[32..64]);
     let rcheck = r.to_bytes();

--- a/src/fortuna.rs
+++ b/src/fortuna.rs
@@ -102,7 +102,7 @@ impl FortunaGenerator {
         let mut hasher = Sha256::new();
         hasher.input(&self.key[..]);
         hasher.input(s);
-        hasher.result(self.key.as_mut_slice());
+        hasher.result(&mut self.key);
         hasher = Sha256::new();
         hasher.input(&self.key[..]);
         hasher.result(&mut self.key[..]);
@@ -134,13 +134,13 @@ impl FortunaGenerator {
         self.generate_blocks(n, &mut out[..(n * AES_BLOCK_SIZE)]);
         if rem > 0 {
             let mut buf = [0; AES_BLOCK_SIZE];
-            self.generate_blocks(1, buf.as_mut_slice());
+            self.generate_blocks(1, &mut buf);
             copy_memory(&mut out[(n * AES_BLOCK_SIZE)..], &buf[..rem]);
         }
 
         // Rekey
         let mut new_key = [0; KEY_LEN];
-        self.generate_blocks(KEY_LEN / AES_BLOCK_SIZE, new_key.as_mut_slice());
+        self.generate_blocks(KEY_LEN / AES_BLOCK_SIZE, &mut new_key);
         self.key = new_key;
     }
 }
@@ -244,7 +244,7 @@ impl Rng for Fortuna {
 
     fn next_u32(&mut self) -> u32 {
         let mut ret = [0; 4];
-        self.fill_bytes(ret.as_mut_slice());
+        self.fill_bytes(&mut ret);
         read_u32_le(&ret[..])
     }
 }
@@ -357,11 +357,11 @@ mod tests {
                          59, 228,  23, 215,  58, 107, 248, 248, 103,  57,
                         127,  31, 241,  91, 230,  33,   0, 164,  77, 46];
         let mut f: Fortuna = SeedableRng::from_seed(&[1, 2, 3, 4][..]);
-        f.fill_bytes(output.as_mut_slice());
+        f.fill_bytes(&mut output);
         assert_eq!(&expected[..], &output[..]);
 
         let mut scratch = [0; (1 << 20)];
-        f.generator.generate_random_data(scratch.as_mut_slice());
+        f.generator.generate_random_data(&mut scratch);
 
         let expected = [122, 164,  26,  67, 102,  65,  30, 217, 219, 113,
                          14,  86, 214, 146, 185,  17, 107, 135, 183,   7,
@@ -373,7 +373,7 @@ mod tests {
                         171, 115, 157, 109, 248, 198, 227,  18, 204, 211,
                          42, 184,  92,  42, 171, 222, 198, 117, 162, 134,
                         116, 109,  77, 195, 187, 139,  37,  78, 224,  63];
-        f.fill_bytes(output.as_mut_slice());
+        f.fill_bytes(&mut output);
         assert_eq!(&expected[..], &output[..]);
 
         f.reseed(&[5]);
@@ -389,7 +389,7 @@ mod tests {
                         101,  10,  29,  33, 133,  87, 189,  36, 229,  56,
                          17, 100, 138,  49,  79, 239, 210, 189, 141,  46];
 
-        f.fill_bytes(output.as_mut_slice());
+        f.fill_bytes(&mut output);
         assert_eq!(&expected[..], &output[..]);
     }
 
@@ -426,7 +426,7 @@ mod tests {
                         226, 168, 179, 246,  82,  42, 223, 239, 201,  23,
                          28,  30, 195, 195,   9, 154,  31, 172, 209, 232,
                         238, 111,  75, 251, 196,  43, 217, 241,  93, 237];
-        f.fill_bytes(output.as_mut_slice());
+        f.fill_bytes(&mut output);
         assert_eq!(&expected[..], &output[..]);
 
         // Immediately (less than 100ms)
@@ -446,7 +446,7 @@ mod tests {
                          19, 167,  56, 192, 140,  93, 132,  78,  22,  16,
                         114,  68, 123, 200,  37, 183, 163, 224, 201, 155,
                         233,  71, 111,  26,   8, 114, 232, 181,  13,  51];
-        f.fill_bytes(output.as_mut_slice());
+        f.fill_bytes(&mut output);
         assert_eq!(&expected[..], &output[..]);
 
         // Simulate more than 100 ms passing
@@ -463,7 +463,7 @@ mod tests {
                          67, 148, 192,  52, 147, 216,  79, 204, 106, 112,
                         238,   0, 239,  99, 159,  96, 184,  90,  54, 122,
                         184, 241, 221, 151, 169,  29, 197,  45,  80,   6];
-        f.fill_bytes(output.as_mut_slice());
+        f.fill_bytes(&mut output);
         assert_eq!(&expected[..], &output[..]);
     }
 }

--- a/src/ghash.rs
+++ b/src/ghash.rs
@@ -573,7 +573,7 @@ mod bench {
         bh.iter( || {
             let mut ghash = Ghash::new(&key);
             ghash.input(&bytes);
-            ghash.raw_result(mac.as_mut_slice());
+            ghash.raw_result(&mut mac);
         });
         bh.bytes = bytes.len() as u64;
     }
@@ -586,7 +586,7 @@ mod bench {
         bh.iter( || {
             let mut ghash = Ghash::new(&key);
             ghash.input(&bytes);
-            ghash.raw_result(mac.as_mut_slice());
+            ghash.raw_result(&mut mac);
         });
         bh.bytes = bytes.len() as u64;
     }
@@ -599,7 +599,7 @@ mod bench {
         bh.iter( || {
             let mut ghash = Ghash::new(&key);
             ghash.input(&bytes);
-            ghash.raw_result(mac.as_mut_slice());
+            ghash.raw_result(&mut mac);
         });
         bh.bytes = bytes.len() as u64;
     }

--- a/src/hc128.rs
+++ b/src/hc128.rs
@@ -249,9 +249,9 @@ mod test {
 
         let mut output = [0u8; 64];
  
-        let mut hc128 = Hc128::new(key.as_slice(), nonce.as_slice());
+        let mut hc128 = Hc128::new(&key, &nonce);
         hc128.process(&input, &mut output);
-        assert!(output.as_slice() == expected_output.as_slice());
+        assert!(&output[..] == &expected_output[..]);
     }
 }
  

--- a/src/hkdf.rs
+++ b/src/hkdf.rs
@@ -60,7 +60,7 @@ pub fn hkdf_expand<D: Digest>(mut digest: D, prk: &[u8], info: &[u8], okm: &mut 
         let nbuf = [n];
         mac.input(info);
         mac.input(&nbuf);
-        mac.raw_result(t.as_mut_slice());
+        mac.raw_result(&mut t);
         mac.reset();
         let chunk_len = chunk.len();
         copy_memory(chunk, &t[..chunk_len]);
@@ -156,12 +156,12 @@ mod test {
 
         for t in test_vectors.iter() {
             let mut prk: Vec<u8> = repeat(0).take(t.prk.len()).collect();
-            hkdf_extract(t.digest, &t.salt[..], &t.ikm[..], prk.as_mut_slice());
+            hkdf_extract(t.digest, &t.salt[..], &t.ikm[..], &mut prk);
             assert!(prk == t.prk);
 
             let mut okm: Vec<u8> = repeat(0).take(t.okm.len()).collect();
             assert!(okm.len() == t.l);
-            hkdf_expand(t.digest, &prk[..], &t.info[..], okm.as_mut_slice());
+            hkdf_expand(t.digest, &prk[..], &t.info[..], &mut okm);
             assert!(okm == t.okm);
         }
     }
@@ -232,12 +232,12 @@ mod test {
 
         for t in test_vectors.iter() {
             let mut prk: Vec<u8> = repeat(0).take(t.prk.len()).collect();
-            hkdf_extract(t.digest, &t.salt[..], &t.ikm[..], prk.as_mut_slice());
+            hkdf_extract(t.digest, &t.salt[..], &t.ikm[..], &mut prk);
             assert!(prk == t.prk);
 
             let mut okm: Vec<u8> = repeat(0).take(t.okm.len()).collect();
             assert!(okm.len() == t.l);
-            hkdf_expand(t.digest, &prk[..], &t.info[..], okm.as_mut_slice());
+            hkdf_expand(t.digest, &prk[..], &t.info[..], &mut okm);
             assert!(okm == t.okm);
         }
     }

--- a/src/hmac.rs
+++ b/src/hmac.rs
@@ -38,7 +38,7 @@ fn expand_key<D: Digest>(digest: &mut D, key: &[u8]) -> Vec<u8> {
     let mut expanded_key: Vec<u8> = repeat(0).take(bs).collect();
 
     if key.len() <= bs {
-        slice::bytes::copy_memory(expanded_key.as_mut_slice(), key);
+        slice::bytes::copy_memory(&mut expanded_key, key);
     } else {
         let output_size = digest.output_bytes();
         digest.input(key);
@@ -53,8 +53,8 @@ fn expand_key<D: Digest>(digest: &mut D, key: &[u8]) -> Vec<u8> {
 fn create_keys<D: Digest>(digest: &mut D, key: &[u8]) -> (Vec<u8>, Vec<u8>) {
     let mut i_key = expand_key(digest, key);
     let mut o_key = i_key.clone();
-    derive_key(i_key.as_mut_slice(), 0x36);
-    derive_key(o_key.as_mut_slice(), 0x5c);
+    derive_key(&mut i_key, 0x36);
+    derive_key(&mut o_key, 0x5c);
     (i_key, o_key)
 }
 
@@ -95,7 +95,7 @@ impl <D: Digest> Mac for Hmac<D> {
         let output_size = self.digest.output_bytes();
         let mut code: Vec<u8> = repeat(0).take(output_size).collect();
 
-        self.raw_result(code.as_mut_slice());
+        self.raw_result(&mut code);
 
         MacResult::new_from_owned(code)
     }

--- a/src/pbkdf2.rs
+++ b/src/pbkdf2.rs
@@ -100,7 +100,7 @@ pub fn pbkdf2<M: Mac>(mac: &mut M, salt: &[u8], c: u32, output: &mut [u8]) {
         idx = idx.checked_add(1).expect("PBKDF2 size limit exceeded.");
 
         if chunk.len() == os {
-            calculate_block(mac, salt, c, idx, scratch.as_mut_slice(), chunk);
+            calculate_block(mac, salt, c, idx, &mut scratch, chunk);
         } else {
             let mut tmp: Vec<u8> = repeat(0).take(os).collect();
             calculate_block(mac, salt, c, idx, &mut scratch[..], &mut tmp[..]);
@@ -321,7 +321,7 @@ mod test {
         for t in tests.iter() {
             let mut mac = Hmac::new(Sha1::new(), &t.password[..]);
             let mut result: Vec<u8> = repeat(0).take(t.expected.len()).collect();
-            pbkdf2(&mut mac, &t.salt[..], t.c, result.as_mut_slice());
+            pbkdf2(&mut mac, &t.salt[..], t.c, &mut result);
             assert!(result == t.expected);
         }
     }

--- a/src/poly1305.rs
+++ b/src/poly1305.rs
@@ -203,7 +203,7 @@ impl Mac for Poly1305 {
 
     fn result(&mut self) -> MacResult {
         let mut mac = [0u8; 16];
-        self.raw_result(mac.as_mut_slice());
+        self.raw_result(&mut mac);
         MacResult::new(&mac[..])
     }
 
@@ -269,7 +269,7 @@ mod test {
         ];
 
         let mut mac = [0u8; 16];
-        poly1305(&key, &msg, mac.as_mut_slice());
+        poly1305(&key, &msg, &mut mac);
         assert_eq!(&mac[..], &expected[..]);
 
         let mut poly = Poly1305::new(&key);
@@ -284,7 +284,7 @@ mod test {
         poly.input(&msg[128..129]);
         poly.input(&msg[129..130]);
         poly.input(&msg[130..131]);
-        poly.raw_result(mac.as_mut_slice());
+        poly.raw_result(&mut mac);
         assert_eq!(&mac[..], &expected[..]);
     }
 
@@ -308,7 +308,7 @@ mod test {
         ];
 
         let mut mac = [0u8; 16];
-        poly1305(&wrap_key, &wrap_msg, mac.as_mut_slice());
+        poly1305(&wrap_key, &wrap_msg, &mut mac);
         assert_eq!(&mac[..], &wrap_mac[..]);
 
         let total_key = [
@@ -345,7 +345,7 @@ mod test {
             0xc2, 0x6b, 0x33, 0xb9, 0x1c, 0xcc, 0x03, 0x07,
         ];
         let mut mac = [0u8; 16];
-        poly1305(key, &msg, mac.as_mut_slice());
+        poly1305(key, &msg, &mut mac);
         assert_eq!(&mac[..], &expected[..]);
 
         let msg = b"Hello world!";
@@ -353,7 +353,7 @@ mod test {
             0xa6, 0xf7, 0x45, 0x00, 0x8f, 0x81, 0xc9, 0x16,
             0xa2, 0x0d, 0xcc, 0x74, 0xee, 0xf2, 0xb2, 0xf0,
         ];
-        poly1305(key, msg, mac.as_mut_slice());
+        poly1305(key, msg, &mut mac);
         assert_eq!(&mac[..], &expected[..]);
     }
 }
@@ -372,7 +372,7 @@ mod bench {
         bh.iter( || {
             let mut poly = Poly1305::new(&key);
             poly.input(&bytes);
-            poly.raw_result(mac.as_mut_slice());
+            poly.raw_result(&mut mac);
         });
         bh.bytes = bytes.len() as u64;
     }
@@ -385,7 +385,7 @@ mod bench {
         bh.iter( || {
             let mut poly = Poly1305::new(&key);
             poly.input(&bytes);
-            poly.raw_result(mac.as_mut_slice());
+            poly.raw_result(&mut mac);
         });
         bh.bytes = bytes.len() as u64;
     }
@@ -398,7 +398,7 @@ mod bench {
         bh.iter( || {
             let mut poly = Poly1305::new(&key);
             poly.input(&bytes);
-            poly.raw_result(mac.as_mut_slice());
+            poly.raw_result(&mut mac);
         });
         bh.bytes = bytes.len() as u64;
     }

--- a/src/rc4.rs
+++ b/src/rc4.rs
@@ -106,7 +106,7 @@ mod test {
         for t in tests.iter() {
             let mut rc4 = Rc4::new(t.key.as_bytes());
             let mut result: Vec<u8> = repeat(0).take(t.output.len()).collect();
-            rc4.process(t.input.as_bytes(), result.as_mut_slice());
+            rc4.process(t.input.as_bytes(), &mut result);
             assert!(result == t.output);
         }
     }

--- a/src/salsa20.rs
+++ b/src/salsa20.rs
@@ -320,7 +320,7 @@ mod test {
         let output_str = "662b9d0e3463029156069b12f918691a98f7dfb2ca0393c96bbfc6b1fbd630a2";
 
         let mut salsa20 = Salsa20::new(&key, &nonce);
-        salsa20.process(input.as_ref(), stream.as_mut_slice());
+        salsa20.process(input.as_ref(), &mut stream);
 
         let mut sh = Sha256::new();
         sh.input(stream.as_ref());

--- a/src/scrypt.rs
+++ b/src/scrypt.rs
@@ -234,16 +234,16 @@ pub fn scrypt(password: &[u8], salt: &[u8], params: &ScryptParams, output: &mut 
     let mut mac = Hmac::new(Sha256::new(), password);
 
     let mut b: Vec<u8> = repeat(0).take(pr128).collect();
-    pbkdf2(&mut mac, salt, 1, b.as_mut_slice());
+    pbkdf2(&mut mac, salt, 1, &mut b);
 
     let mut v: Vec<u8> = repeat(0).take(nr128).collect();
     let mut t: Vec<u8> = repeat(0).take(r128).collect();
 
-    for chunk in b.as_mut_slice().chunks_mut(r128) {
-        scrypt_ro_mix(chunk, v.as_mut_slice(), t.as_mut_slice(), n);
+    for chunk in &mut b.chunks_mut(r128) {
+        scrypt_ro_mix(chunk, &mut v, &mut t, n);
     }
 
-    pbkdf2(&mut mac, &*b, 1, output.as_mut_slice());
+    pbkdf2(&mut mac, &*b, 1, output);
 }
 
 /**
@@ -396,7 +396,7 @@ pub fn scrypt_check(password: &str, hashed_value: &str) -> Result<bool, &'static
     }
 
     let mut output: Vec<u8> = repeat(0).take(hash.len()).collect();
-    scrypt(password.as_bytes(), &*salt, &params, output.as_mut_slice());
+    scrypt(password.as_bytes(), &*salt, &params, &mut output);
 
     // Be careful here - its important that the comparison be done using a fixed time equality
     // check. Otherwise an adversary that can measure how long this step takes can learn about the
@@ -481,7 +481,7 @@ mod test {
         for t in tests.iter() {
             let mut result: Vec<u8> = repeat(0).take(t.expected.len()).collect();
             let params = ScryptParams::new(t.log_n, t.r, t.p);
-            scrypt(t.password.as_bytes(), t.salt.as_bytes(), &params, result.as_mut_slice());
+            scrypt(t.password.as_bytes(), t.salt.as_bytes(), &params, &mut result);
             assert!(result == t.expected);
         }
     }

--- a/src/whirlpool.rs
+++ b/src/whirlpool.rs
@@ -20,7 +20,7 @@ For details see <http://www.larc.usp.br/~pbarreto/WhirlpoolPage.html>.
 # Usage
 
 ```rust
-use self::crypto::whirlpool::Whirlpool;
+use self::crypto::swhirlpool::Whirlpool;
 use self::crypto::digest::Digest;
 
 let mut hasher = Whirlpool::new();


### PR DESCRIPTION
This should fix the build for the latest nightly. Note that I didn't use the `x.as_mut_ref()` solution, but instead used `&mut x`. I believe this is the preferred way of denoting a slice.

The doc tests still fail on my machine. I couldn't get them to compile..