### PR TITLE
Fixups for breaking Rust changes

### DIFF
--- a/src/aes_gcm.rs
+++ b/src/aes_gcm.rs
@@ -33,7 +33,7 @@ impl<'a> AesGcm<'a> {
         // earlier preventing the use of generic CTR mode.
 
         let mut iv = [0u8; 16];
-        copy_memory(&mut iv, nonce);
+        copy_memory(nonce, &mut iv);
         iv[15] = 1u8;
         let mut cipher = ctr(key_size,key,&iv);
         let temp_block = [0u8; 16];

--- a/src/aessafe.rs
+++ b/src/aessafe.rs
@@ -124,7 +124,6 @@ finite field which allows for efficient computation of the AES S-Boxes. See [7] 
 */
 
 use std::ops::{BitAnd, BitXor, Not};
-use std::num::Int;
 use std::default::Default;
 
 use cryptoutil::{read_u32v_le, write_u32_le};

--- a/src/blake2b.rs
+++ b/src/blake2b.rs
@@ -122,7 +122,7 @@ impl Blake2b {
             key: [0; BLAKE2B_KEYBYTES],
             key_length: key.len() as u8
         };
-        copy_memory(&mut b.key, key);
+        copy_memory(key, &mut b.key);
         b
     }
 
@@ -184,7 +184,7 @@ impl Blake2b {
 
     fn apply_key(&mut self) {
         let mut block : [u8; BLAKE2B_BLOCKBYTES] = [0; BLAKE2B_BLOCKBYTES];
-        copy_memory(&mut block, &self.key[..self.key_length as usize]);
+        copy_memory(&self.key[..self.key_length as usize], &mut block);
         self.update(&block);
         unsafe {
             volatile_set_memory(block.as_mut_ptr(), 0, block.len());
@@ -256,7 +256,7 @@ impl Blake2b {
             let fill = 2 * BLAKE2B_BLOCKBYTES - left;
 
             if input.len() > fill {
-                copy_memory( &mut self.buf[left..], &input[0..fill] ); // Fill buffer
+                copy_memory(&input[0..fill], &mut self.buf[left..]); // Fill buffer
                 self.buflen += fill;
                 self.increment_counter( BLAKE2B_BLOCKBYTES as u64);
                 self.compress();
@@ -264,12 +264,12 @@ impl Blake2b {
                 let mut halves = self.buf.chunks_mut(BLAKE2B_BLOCKBYTES);
                 let first_half = halves.next().unwrap();
                 let second_half = halves.next().unwrap();
-                copy_memory(first_half, second_half);
+                copy_memory(second_half, first_half);
 
                 self.buflen -= BLAKE2B_BLOCKBYTES;
                 input = &input[fill..input.len()];
             } else { // inlen <= fill
-                copy_memory(&mut self.buf[left..], input);
+                copy_memory(input, &mut self.buf[left..]);
                 self.buflen += input.len();
                 break;
             }
@@ -287,7 +287,7 @@ impl Blake2b {
                 let mut halves = self.buf.chunks_mut(BLAKE2B_BLOCKBYTES);
                 let first_half = halves.next().unwrap();
                 let second_half = halves.next().unwrap();
-                copy_memory(first_half, second_half);
+                copy_memory(second_half, first_half);
             }
 
             let incby = self.buflen as u64;
@@ -304,7 +304,7 @@ impl Blake2b {
             self.computed = true;
         }
         let outlen = out.len();
-        copy_memory(out, &self.buf[0..outlen]);
+        copy_memory(&self.buf[0..outlen], out);
     }
 
     pub fn blake2b(out: &mut[u8], input: &[u8], key: &[u8]) {

--- a/src/blake2b.rs
+++ b/src/blake2b.rs
@@ -5,7 +5,6 @@
 // except according to those terms.
 
 use std::iter::repeat;
-use std::num::Int;
 use cryptoutil::{read_u64v_le, write_u64v_le};
 use std::slice::bytes::{copy_memory};
 use std::intrinsics::volatile_set_memory;

--- a/src/blockmodes.rs
+++ b/src/blockmodes.rs
@@ -94,14 +94,14 @@ fn update_history(in_hist: &mut [u8], out_hist: &mut [u8], last_in: &[u8], last_
     let in_hist_len = in_hist.len();
     if in_hist_len > 0 {
         slice::bytes::copy_memory(
-            in_hist,
-            &last_in[last_in.len() - in_hist_len..]);
+            &last_in[last_in.len() - in_hist_len..],
+            in_hist);
     }
     let out_hist_len = out_hist.len();
     if out_hist_len > 0 {
         slice::bytes::copy_memory(
-            out_hist,
-            &last_out[last_out.len() - out_hist_len..]);
+            &last_out[last_out.len() - out_hist_len..],
+            out_hist);
     }
 }
 
@@ -412,8 +412,8 @@ impl <P: BlockProcessor, X: PaddingProcessor> BlockEngine<P, X> {
     }
     fn reset_with_history(&mut self, in_hist: &[u8], out_hist: &[u8]) {
         self.reset();
-        slice::bytes::copy_memory(&mut self.in_hist, in_hist);
-        slice::bytes::copy_memory(&mut self.out_hist, out_hist);
+        slice::bytes::copy_memory(in_hist, &mut self.in_hist);
+        slice::bytes::copy_memory(out_hist, &mut self.out_hist);
     }
 }
 
@@ -690,7 +690,7 @@ impl <A: BlockEncryptor> CtrMode<A> {
         }
     }
     pub fn reset(&mut self, ctr: &[u8]) {
-        slice::bytes::copy_memory(&mut self.ctr, ctr);
+        slice::bytes::copy_memory(ctr, &mut self.ctr);
         self.bytes.reset();
     }
     fn process(&mut self, input: &[u8], output: &mut [u8]) {
@@ -744,7 +744,7 @@ pub struct CtrModeX8<A> {
 
 fn construct_ctr_x8(in_ctr: &[u8], out_ctr_x8: &mut [u8]) {
     for (i, ctr_i) in out_ctr_x8.chunks_mut(in_ctr.len()).enumerate() {
-        slice::bytes::copy_memory(ctr_i, in_ctr);
+        slice::bytes::copy_memory(in_ctr, ctr_i);
         add_ctr(ctr_i, i as u8);
     }
 }

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -37,7 +37,7 @@ pub trait ReadBuffer {
 
     fn push_to<W: WriteBuffer>(&mut self, output: &mut W) {
         let count = cmp::min(output.remaining(), self.remaining());
-        slice::bytes::copy_memory(output.take_next(count), self.take_next(count));
+        slice::bytes::copy_memory(self.take_next(count), output.take_next(count));
     }
 }
 

--- a/src/cryptoutil.rs
+++ b/src/cryptoutil.rs
@@ -25,7 +25,7 @@ pub fn write_u64_be(dst: &mut[u8], mut input: u64) {
     input = input.to_be();
     unsafe {
         let tmp = &input as *const _ as *const u8;
-        ptr::copy_nonoverlapping(dst.get_unchecked_mut(0), tmp, 8);
+        ptr::copy_nonoverlapping(tmp, dst.get_unchecked_mut(0), 8);
     }
 }
 
@@ -36,7 +36,7 @@ pub fn write_u64_le(dst: &mut[u8], mut input: u64) {
     input = input.to_le();
     unsafe {
         let tmp = &input as *const _ as *const u8;
-        ptr::copy_nonoverlapping(dst.get_unchecked_mut(0), tmp, 8);
+        ptr::copy_nonoverlapping(tmp, dst.get_unchecked_mut(0), 8);
     }
 }
 
@@ -48,7 +48,7 @@ pub fn write_u64v_le(dst: &mut[u8], input: &[u64]) {
         let mut y: *const u64 = input.get_unchecked(0);
         for _ in (0..input.len()) {
             let tmp = (*y).to_le();
-            ptr::copy_nonoverlapping(x, &tmp as *const _ as *const u8, 8);
+            ptr::copy_nonoverlapping(&tmp as *const _ as *const u8, x, 8);
             x = x.offset(8);
             y = y.offset(1);
         }
@@ -62,7 +62,7 @@ pub fn write_u32_be(dst: &mut [u8], mut input: u32) {
     input = input.to_be();
     unsafe {
         let tmp = &input as *const _ as *const u8;
-        ptr::copy_nonoverlapping(dst.get_unchecked_mut(0), tmp, 4);
+        ptr::copy_nonoverlapping(tmp, dst.get_unchecked_mut(0), 4);
     }
 }
 
@@ -73,7 +73,7 @@ pub fn write_u32_le(dst: &mut[u8], mut input: u32) {
     input = input.to_le();
     unsafe {
         let tmp = &input as *const _ as *const u8;
-        ptr::copy_nonoverlapping(dst.get_unchecked_mut(0), tmp, 4);
+        ptr::copy_nonoverlapping(tmp, dst.get_unchecked_mut(0), 4);
     }
 }
 
@@ -85,7 +85,7 @@ pub fn write_u32v_le (dst: &mut[u8], input: &[u32]) {
         let mut y: *const u32 = input.get_unchecked(0);
         for _ in 0..input.len() {
             let tmp = (*y).to_le();
-            ptr::copy_nonoverlapping(x, &tmp as *const _ as *const u8, 4);
+            ptr::copy_nonoverlapping(&tmp as *const _ as *const u8, x, 4);
             x = x.offset(4);
             y = y.offset(1);
         }
@@ -100,7 +100,7 @@ pub fn read_u64v_be(dst: &mut[u64], input: &[u8]) {
         let mut y: *const u8 = input.get_unchecked(0);
         for _ in (0..dst.len()) {
             let mut tmp: u64 = mem::uninitialized();
-            ptr::copy_nonoverlapping(&mut tmp as *mut _ as *mut u8, y, 8);
+            ptr::copy_nonoverlapping(y, &mut tmp as *mut _ as *mut u8, 8);
             *x = Int::from_be(tmp);
             x = x.offset(1);
             y = y.offset(8);
@@ -116,7 +116,7 @@ pub fn read_u64v_le(dst: &mut[u64], input: &[u8]) {
         let mut y: *const u8 = input.get_unchecked(0);
         for _ in (0..dst.len()) {
             let mut tmp: u64 = mem::uninitialized();
-            ptr::copy_nonoverlapping(&mut tmp as *mut _ as *mut u8, y, 8);
+            ptr::copy_nonoverlapping(y, &mut tmp as *mut _ as *mut u8, 8);
             *x = Int::from_le(tmp);
             x = x.offset(1);
             y = y.offset(8);
@@ -132,7 +132,7 @@ pub fn read_u32v_be(dst: &mut[u32], input: &[u8]) {
         let mut y: *const u8 = input.get_unchecked(0);
         for _ in (0..dst.len()) {
             let mut tmp: u32 = mem::uninitialized();
-            ptr::copy_nonoverlapping(&mut tmp as *mut _ as *mut u8, y, 4);
+            ptr::copy_nonoverlapping(y, &mut tmp as *mut _ as *mut u8, 4);
             *x = Int::from_be(tmp);
             x = x.offset(1);
             y = y.offset(4);
@@ -148,7 +148,7 @@ pub fn read_u32v_le(dst: &mut[u32], input: &[u8]) {
         let mut y: *const u8 = input.get_unchecked(0);
         for _ in (0..dst.len()) {
             let mut tmp: u32 = mem::uninitialized();
-            ptr::copy_nonoverlapping(&mut tmp as *mut _ as *mut u8, y, 4);
+            ptr::copy_nonoverlapping(y, &mut tmp as *mut _ as *mut u8, 4);
             *x = Int::from_le(tmp);
             x = x.offset(1);
             y = y.offset(4);
@@ -161,7 +161,7 @@ pub fn read_u32_le(input: &[u8]) -> u32 {
     assert!(input.len() == 4);
     unsafe {
         let mut tmp: u32 = mem::uninitialized();
-        ptr::copy_nonoverlapping(&mut tmp as *mut _ as *mut u8, input.get_unchecked(0), 4);
+        ptr::copy_nonoverlapping(input.get_unchecked(0), &mut tmp as *mut _ as *mut u8, 4);
         Int::from_le(tmp)
     }
 }
@@ -171,7 +171,7 @@ pub fn read_u32_be(input: &[u8]) -> u32 {
     assert!(input.len() == 4);
     unsafe {
         let mut tmp: u32 = mem::uninitialized();
-        ptr::copy_nonoverlapping(&mut tmp as *mut _ as *mut u8, input.get_unchecked(0), 4);
+        ptr::copy_nonoverlapping(input.get_unchecked(0), &mut tmp as *mut _ as *mut u8, 4);
         Int::from_be(tmp)
     }
 }
@@ -364,15 +364,15 @@ macro_rules! impl_fixed_buffer( ($name:ident, $size:expr) => (
                 let buffer_remaining = size - self.buffer_idx;
                 if input.len() >= buffer_remaining {
                         copy_memory(
-                            &mut self.buffer[self.buffer_idx..size],
-                            &input[..buffer_remaining]);
+                            &input[..buffer_remaining],
+                            &mut self.buffer[self.buffer_idx..size]);
                     self.buffer_idx = 0;
                     func(&self.buffer);
                     i += buffer_remaining;
                 } else {
                     copy_memory(
-                        &mut self.buffer[self.buffer_idx..self.buffer_idx + input.len()],
-                        input);
+                        input,
+                        &mut self.buffer[self.buffer_idx..self.buffer_idx + input.len()]);
                     self.buffer_idx += input.len();
                     return;
                 }
@@ -390,8 +390,8 @@ macro_rules! impl_fixed_buffer( ($name:ident, $size:expr) => (
             // be empty.
             let input_remaining = input.len() - i;
             copy_memory(
-                &mut self.buffer[0..input_remaining],
-                &input[i..]);
+                &input[i..],
+                &mut self.buffer[0..input_remaining]);
             self.buffer_idx += input_remaining;
         }
 

--- a/src/fortuna.rs
+++ b/src/fortuna.rs
@@ -135,7 +135,7 @@ impl FortunaGenerator {
         if rem > 0 {
             let mut buf = [0; AES_BLOCK_SIZE];
             self.generate_blocks(1, &mut buf);
-            copy_memory(&mut out[(n * AES_BLOCK_SIZE)..], &buf[..rem]);
+            copy_memory(&buf[..rem], &mut out[(n * AES_BLOCK_SIZE)..]);
         }
 
         // Rekey

--- a/src/ghash.rs
+++ b/src/ghash.rs
@@ -161,13 +161,13 @@ fn update(state: &mut Gf128, len: &mut usize, data: &[u8], srest: &mut Option<[u
         None => data,
         Some(mut rest) => {
             if 16 - rest_len > data_len {
-                copy_memory(&mut rest[rest_len..], data);
+                copy_memory(data, &mut rest[rest_len..]);
                 *srest = Some(rest);
                 return;
             }
 
             let (fill, data) = data.split_at(16 - rest_len);
-            copy_memory(&mut rest[rest_len..], fill);
+            copy_memory(fill, &mut rest[rest_len..]);
             state.add_and_mul(Gf128::from_bytes(&rest), hs);
             data
         }
@@ -182,7 +182,7 @@ fn update(state: &mut Gf128, len: &mut usize, data: &[u8], srest: &mut Option<[u
 
     if rest.len() != 0 {
         let mut tmp = [0; 16];
-        copy_memory(&mut tmp, rest);
+        copy_memory(rest, &mut tmp);
         *srest = Some(tmp);
     }
 }
@@ -316,7 +316,7 @@ impl Mac for Ghash {
             self.finished = true;
         }
 
-        copy_memory(output, &self.state.to_bytes());
+        copy_memory(&self.state.to_bytes(), output);
     }
 
     fn output_bytes(&self) -> usize { 16 }

--- a/src/hc128.rs
+++ b/src/hc128.rs
@@ -9,7 +9,6 @@ use buffer::{BufferResult, RefReadBuffer, RefWriteBuffer};
 use symmetriccipher::{Encryptor, Decryptor, SynchronousStreamCipher, SymmetricCipherError};
 use cryptoutil::{read_u32_le, symm_enc_or_dec, write_u32_le};
  
-use std::num::Int;
 use std::ptr;
 
 

--- a/src/hc128.rs
+++ b/src/hc128.rs
@@ -41,14 +41,14 @@ impl Hc128 {
             w[i >> 2] |= (key[i] as u32) << (8 * (i & 0x3));
         }
         unsafe {
-            ptr::copy_nonoverlapping(w.as_mut_ptr().offset(4), w.as_ptr(), 4);
+            ptr::copy_nonoverlapping(w.as_ptr(), w.as_mut_ptr().offset(4), 4);
         }
 
         for i in (0..nonce.len() & 16) {
             w[(i >> 2) + 8] |= (nonce[i] as u32) << (8 * (i & 0x3));
         }
         unsafe {
-            ptr::copy_nonoverlapping(w.as_mut_ptr().offset(12), w.as_ptr().offset(8), 4);
+            ptr::copy_nonoverlapping(w.as_ptr().offset(8), w.as_mut_ptr().offset(12), 4);
         }
 
         for i in 16..1280 {
@@ -57,8 +57,8 @@ impl Hc128 {
 
         // Copy contents of w into p and q
         unsafe {
-            ptr::copy_nonoverlapping(self.p.as_mut_ptr(), w.as_ptr().offset(256), 512);
-            ptr::copy_nonoverlapping(self.q.as_mut_ptr(), w.as_ptr().offset(768), 512);
+            ptr::copy_nonoverlapping(w.as_ptr().offset(256), self.p.as_mut_ptr(),  512);
+            ptr::copy_nonoverlapping(w.as_ptr().offset(768), self.q.as_mut_ptr(), 512);
         }
         
         for i in 0..512 {

--- a/src/hkdf.rs
+++ b/src/hkdf.rs
@@ -63,7 +63,7 @@ pub fn hkdf_expand<D: Digest>(mut digest: D, prk: &[u8], info: &[u8], okm: &mut 
         mac.raw_result(&mut t);
         mac.reset();
         let chunk_len = chunk.len();
-        copy_memory(chunk, &t[..chunk_len]);
+        copy_memory(&t[..chunk_len], chunk);
     }
 }
 

--- a/src/hkdf.rs
+++ b/src/hkdf.rs
@@ -8,7 +8,6 @@
 //! Derivation Function as specified by  https://tools.ietf.org/html/rfc5869.
 
 use std::iter::repeat;
-use std::num::Int;
 use std::slice::bytes::copy_memory;
 
 use digest::Digest;

--- a/src/hmac.rs
+++ b/src/hmac.rs
@@ -38,7 +38,7 @@ fn expand_key<D: Digest>(digest: &mut D, key: &[u8]) -> Vec<u8> {
     let mut expanded_key: Vec<u8> = repeat(0).take(bs).collect();
 
     if key.len() <= bs {
-        slice::bytes::copy_memory(&mut expanded_key, key);
+        slice::bytes::copy_memory(key, &mut expanded_key);
     } else {
         let output_size = digest.output_bytes();
         digest.input(key);

--- a/src/md5.rs
+++ b/src/md5.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::num::Int;
-
 use cryptoutil::{write_u32_le, read_u32v_le, FixedBuffer, FixedBuffer64, StandardPadding};
 use digest::Digest;
 

--- a/src/pbkdf2.rs
+++ b/src/pbkdf2.rs
@@ -11,7 +11,6 @@
 
 use std::iter::repeat;
 use std::io;
-use std::num::Int;
 use std::slice::bytes::copy_memory;
 
 use rand::{OsRng, Rng};

--- a/src/pbkdf2.rs
+++ b/src/pbkdf2.rs
@@ -105,7 +105,7 @@ pub fn pbkdf2<M: Mac>(mac: &mut M, salt: &[u8], c: u32, output: &mut [u8]) {
             let mut tmp: Vec<u8> = repeat(0).take(os).collect();
             calculate_block(mac, salt, c, idx, &mut scratch[..], &mut tmp[..]);
             let chunk_len = chunk.len();
-            copy_memory(chunk, &tmp[..chunk_len]);
+            copy_memory(&tmp[..chunk_len], chunk);
         }
     }
 }

--- a/src/scrypt.rs
+++ b/src/scrypt.rs
@@ -97,7 +97,7 @@ fn xor(x: &[u8], y: &[u8], output: &mut [u8]) {
 // output - the output vector. Must be the same length as input.
 fn scrypt_block_mix(input: &[u8], output: &mut [u8]) {
     let mut x = [0u8; 64];
-    copy_memory(&mut x, &input[input.len() - 64..]);
+    copy_memory(&input[input.len() - 64..], &mut x);
 
     let mut t = [0u8; 64];
 
@@ -105,7 +105,7 @@ fn scrypt_block_mix(input: &[u8], output: &mut [u8]) {
         xor(&x, chunk, &mut t);
         salsa20_8(&t, &mut x);
         let pos = if i % 2 == 0 { (i / 2) * 64 } else { (i / 2) * 64 + input.len() / 2 };
-        copy_memory(&mut output[pos..pos + 64], &x);
+        copy_memory(&x, &mut output[pos..pos + 64]);
     }
 }
 
@@ -128,7 +128,7 @@ fn scrypt_ro_mix(b: &mut [u8], v: &mut [u8], t: &mut [u8], n: usize) {
     let len = b.len();
 
     for chunk in v.chunks_mut(len) {
-        copy_memory(chunk, b);
+        copy_memory(b, chunk);
         scrypt_block_mix(chunk, b);
     }
 

--- a/src/sha1.rs
+++ b/src/sha1.rs
@@ -60,7 +60,6 @@ Some of these functions are commonly found in all hash digest
 algorithms, but some, like "parity" is only found in SHA-1.
  */
 
-use std::num::Int;
 use digest::Digest;
 use cryptoutil::{write_u32_be, read_u32v_be, add_bytes_to_bits, FixedBuffer, FixedBuffer64, StandardPadding};
 use simd::u32x4;

--- a/src/sha2.rs
+++ b/src/sha2.rs
@@ -70,7 +70,6 @@ assert_eq!(hex,
 
  */
 
-use std::num::Int;
 use digest::Digest;
 use cryptoutil::{write_u32_be, read_u32v_be,
                  write_u64_be, read_u64v_be,

--- a/src/sosemanuk.rs
+++ b/src/sosemanuk.rs
@@ -9,7 +9,6 @@ use buffer::{BufferResult, RefReadBuffer, RefWriteBuffer};
 use symmetriccipher::{Encryptor, Decryptor, SynchronousStreamCipher, SymmetricCipherError};
 use cryptoutil::{read_u32_le, symm_enc_or_dec, write_u32v_le};
  
-use std::num::Int;
 use std::slice::bytes::copy_memory;
 
 

--- a/src/sosemanuk.rs
+++ b/src/sosemanuk.rs
@@ -598,10 +598,10 @@ impl Sosemanuk {
 fn key_setup(key : &[u8], subkeys : &mut[u32; 100]) {
     let mut full_key : [u8; 32] = [0; 32];
     if key.len() < 32 {
-        copy_memory(&mut full_key[0..key.len()], &key);
+        copy_memory(&key, &mut full_key[0..key.len()]);
         full_key[key.len()] = 0x01;
     } else {
-        copy_memory(&mut full_key[0..32], &key[0..32]);
+        copy_memory(&key[0..32], &mut full_key[0..32]);
     }
  
     let mut w0 = read_u32_le(&full_key[0..4]);
@@ -1488,9 +1488,9 @@ fn key_setup(key : &[u8], subkeys : &mut[u32; 100]) {
 fn iv_setup(iv : &[u8], subkeys : &mut[u32; 100], lfsr : &mut[u32; 10], fsm_r : &mut[u32; 2]) {
     let mut nonce : [u8; 16] = [0; 16];
     if iv.len() < 16 {
-        copy_memory(&mut nonce[0..iv.len()], &iv);
+        copy_memory(&iv, &mut nonce[0..iv.len()]);
     } else {
-        copy_memory(&mut nonce[0..16], &iv[0..16]);
+        copy_memory(&iv[0..16], &mut nonce[0..16]);
     }
  
     let mut r0 : u32;


### PR DESCRIPTION
This PR should fix breakages that will be caused by the next Rust nightly:

* The order of operands to some functions has been changed.
* The Int trait has been deprecated.