### PR TITLE
util: replace arch specific fixed_time_eq() with a generic version based on openssl and gnutls's equivalent functions

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -19,7 +19,7 @@ pub fn supports_aesni() -> bool {
 }
 
 extern {
-    pub fn rust_crypto_util_fixed_time_eq_asm(
+    pub fn rust_crypto_util_fixed_time_eq(
             lhsp: *const u8,
             rhsp: *const u8,
             count: libc::size_t) -> u32;
@@ -51,7 +51,7 @@ pub fn fixed_time_eq(lhs: &[u8], rhs: &[u8]) -> bool {
         unsafe {
             let lhsp = lhs.get_unchecked(0);
             let rhsp = rhs.get_unchecked(0);
-            rust_crypto_util_fixed_time_eq_asm(lhsp, rhsp, count) == 0
+            rust_crypto_util_fixed_time_eq(lhsp, rhsp, count) == 0
         }
     }
 }

--- a/src/util_helpers.c
+++ b/src/util_helpers.c
@@ -21,56 +21,15 @@ uint32_t rust_crypto_util_supports_aesni() {
 }
 #endif
 
-#if defined(__i386__) || defined(__x86_64__)
-uint32_t rust_crypto_util_fixed_time_eq_asm(uint8_t* lhsp, uint8_t* rhsp, size_t count) {
-    uint8_t result = 0;
-    asm(
-        " \
-            1: \
-            \
-            mov (%1), %%cl; \
-            xor (%2), %%cl; \
-            or %%cl, %0; \
-            \
-            inc %1; \
-            inc %2; \
-            dec %3; \
-            jnz 1b; \
-        "
-        : "+&r" (result), "+&r" (lhsp), "+&r" (rhsp), "+&r" (count) // all input and output
-        : // input
-        : "cl", "cc" // clobbers
-    );
+uint32_t rust_crypto_util_fixed_time_eq(uint8_t* lhsp, uint8_t* rhsp, size_t count) {
+	size_t i;
+	uint32_t status = 0;
 
-    return result;
+	for (i=0; i < count; i++)
+		status |= lhsp[i] ^ rhsp[i];
+
+	return status;
 }
-#endif
-
-#ifdef __arm__
-uint32_t rust_crypto_util_fixed_time_eq_asm(uint8_t* lhsp, uint8_t* rhsp, size_t count) {
-    uint8_t result = 0;
-    asm(
-        " \
-            1: \
-            \
-            ldrb r4, [$1] \
-            ldrb r5, [$2] \
-            eor r4, r4, r5 \
-            orr $0, $0, r4 \
-            \
-            add $1, $1, #1 \
-            add $2, $2, #1 \
-            subs $3, $3, #1 \
-            bne 1b \
-        "
-        : "+&r" (result), "+&r" (lhsp), "+&r" (rhsp), "+&r" (count) // all input and output
-        : // input
-        : "r4", "r5", "cc" // clobbers
-    );
-
-    return result;
-}
-#endif
 
 void rust_crypto_util_secure_memset(uint8_t* dst, uint8_t val, size_t count) {
     memset(dst, val, count);


### PR DESCRIPTION

Should fix #302