### PR TITLE
Prevent GCC from removing inline assembly

### DIFF
--- a/src/aesni_helpers.c
+++ b/src/aesni_helpers.c
@@ -9,7 +9,7 @@
 #if defined(__i386__) || defined(__x86_64__)
 
 void rust_crypto_aesni_aesimc(uint8_t* round_keys) {
-    asm(
+    asm volatile(
         " \
             movdqu (%0), %%xmm1; \
             aesimc %%xmm1, %%xmm1; \
@@ -24,7 +24,7 @@ void rust_crypto_aesni_aesimc(uint8_t* round_keys) {
 void rust_crypto_aesni_setup_working_key_128(
         uint8_t* key,
         uint8_t* round_key) {
-    asm(
+    asm volatile(
         " \
             movdqu (%1), %%xmm1; \
             movdqu %%xmm1, (%0); \
@@ -77,7 +77,7 @@ void rust_crypto_aesni_setup_working_key_128(
 void rust_crypto_aesni_setup_working_key_192(
         uint8_t* key,
         uint8_t* round_key) {
-    asm(
+    asm volatile(
         " \
             movdqu (%1), %%xmm1; \
             movdqu 16(%1), %%xmm3; \
@@ -165,7 +165,7 @@ void rust_crypto_aesni_setup_working_key_192(
 void rust_crypto_aesni_setup_working_key_256(
         uint8_t* key,
         uint8_t* round_key) {
-    asm(
+    asm volatile(
         " \
             movdqu (%1), %%xmm1; \
             movdqu 16(%1), %%xmm3; \
@@ -263,7 +263,7 @@ void rust_crypto_aesni_encrypt_block(
             uint8_t* input,
             uint8_t* round_keys,
             uint8_t* output) {
-    asm(
+    asm volatile(
     " \
         /* Copy the data to encrypt to xmm1 */ \
         movdqu (%2), %%xmm1; \
@@ -300,7 +300,7 @@ void rust_crypto_aesni_decrypt_block(
             uint8_t* input,
             uint8_t* round_keys,
             uint8_t* output) {
-    asm(
+    asm volatile(
         " \
             /* Copy the data to decrypt to xmm1 */ \
             movdqu (%2), %%xmm1; \


### PR DESCRIPTION
Disassembly of `rust_crypto_aesni_setup_working_key_128` on master:

```
0000000000000000 <rust_crypto_aesni_setup_working_key_128>:
   0:   55                      push   %rbp
   1:   48 89 e5                mov    %rsp,%rbp
   4:   48 81 ec 30 10 00 00    sub    $0x1030,%rsp
   b:   48 83 0c 24 00          orq    $0x0,(%rsp)
  10:   48 81 c4 20 10 00 00    add    $0x1020,%rsp
  17:   64 48 8b 04 25 28 00    mov    %fs:0x28,%rax
  1e:   00 00 
  20:   48 89 45 f8             mov    %rax,-0x8(%rbp)
  24:   31 c0                   xor    %eax,%eax
  26:   48 8b 45 f8             mov    -0x8(%rbp),%rax
  2a:   64 48 33 04 25 28 00    xor    %fs:0x28,%rax
  31:   00 00 
  33:   75 02                   jne    37 <rust_crypto_aesni_setup_working_key_128+0x37>
  35:   c9                      leaveq 
  36:   c3                      retq   
  37:   e8 00 00 00 00          callq  3c <rust_crypto_aesni_setup_working_key_128+0x3c>
```

Note that the inline assembly has been optimized out.

Fixed:

```
0000000000000000 <rust_crypto_aesni_setup_working_key_128>:
   0:   55                      push   %rbp
   1:   48 89 e5                mov    %rsp,%rbp
   4:   48 81 ec 30 10 00 00    sub    $0x1030,%rsp
   b:   48 83 0c 24 00          orq    $0x0,(%rsp)
  10:   48 81 c4 20 10 00 00    add    $0x1020,%rsp
  17:   64 48 8b 04 25 28 00    mov    %fs:0x28,%rax
  1e:   00 00 
  20:   48 89 45 f8             mov    %rax,-0x8(%rbp)
  24:   31 c0                   xor    %eax,%eax
  26:   f3 0f 6f 0f             movdqu (%rdi),%xmm1
  2a:   f3 0f 7f 0e             movdqu %xmm1,(%rsi)
  2e:   48 83 c6 10             add    $0x10,%rsi
  32:   66 0f 3a df d1 01       aeskeygenassist $0x1,%xmm1,%xmm2
  38:   e8 65 00 00 00          callq  a2 <rust_crypto_aesni_setup_working_key_128+0xa2>
  3d:   66 0f 3a df d1 02       aeskeygenassist $0x2,%xmm1,%xmm2
  43:   e8 5a 00 00 00          callq  a2 <rust_crypto_aesni_setup_working_key_128+0xa2>
  48:   66 0f 3a df d1 04       aeskeygenassist $0x4,%xmm1,%xmm2
  4e:   e8 4f 00 00 00          callq  a2 <rust_crypto_aesni_setup_working_key_128+0xa2>
  53:   66 0f 3a df d1 08       aeskeygenassist $0x8,%xmm1,%xmm2
  59:   e8 44 00 00 00          callq  a2 <rust_crypto_aesni_setup_working_key_128+0xa2>
  5e:   66 0f 3a df d1 10       aeskeygenassist $0x10,%xmm1,%xmm2
  64:   e8 39 00 00 00          callq  a2 <rust_crypto_aesni_setup_working_key_128+0xa2>
  69:   66 0f 3a df d1 20       aeskeygenassist $0x20,%xmm1,%xmm2
  6f:   e8 2e 00 00 00          callq  a2 <rust_crypto_aesni_setup_working_key_128+0xa2>
  74:   66 0f 3a df d1 40       aeskeygenassist $0x40,%xmm1,%xmm2
  7a:   e8 23 00 00 00          callq  a2 <rust_crypto_aesni_setup_working_key_128+0xa2>
  7f:   66 0f 3a df d1 80       aeskeygenassist $0x80,%xmm1,%xmm2
  85:   e8 18 00 00 00          callq  a2 <rust_crypto_aesni_setup_working_key_128+0xa2>
  8a:   66 0f 3a df d1 1b       aeskeygenassist $0x1b,%xmm1,%xmm2
  90:   e8 0d 00 00 00          callq  a2 <rust_crypto_aesni_setup_working_key_128+0xa2>
  95:   66 0f 3a df d1 36       aeskeygenassist $0x36,%xmm1,%xmm2
  9b:   e8 02 00 00 00          callq  a2 <rust_crypto_aesni_setup_working_key_128+0xa2>
  a0:   eb 2d                   jmp    cf <rust_crypto_aesni_setup_working_key_128+0xcf>
  a2:   66 0f 70 d2 ff          pshufd $0xff,%xmm2,%xmm2
  a7:   c5 e1 73 f9 04          vpslldq $0x4,%xmm1,%xmm3
  ac:   66 0f ef cb             pxor   %xmm3,%xmm1
  b0:   c5 e1 73 f9 04          vpslldq $0x4,%xmm1,%xmm3
  b5:   66 0f ef cb             pxor   %xmm3,%xmm1
  b9:   c5 e1 73 f9 04          vpslldq $0x4,%xmm1,%xmm3
  be:   66 0f ef cb             pxor   %xmm3,%xmm1
  c2:   66 0f ef ca             pxor   %xmm2,%xmm1
  c6:   f3 0f 7f 0e             movdqu %xmm1,(%rsi)
  ca:   48 83 c6 10             add    $0x10,%rsi
  ce:   c3                      retq   
  cf:   48 8b 45 f8             mov    -0x8(%rbp),%rax
  d3:   64 48 33 04 25 28 00    xor    %fs:0x28,%rax
  da:   00 00 
  dc:   75 02                   jne    e0 <rust_crypto_aesni_setup_working_key_128+0xe0>
  de:   c9                      leaveq 
  df:   c3                      retq   
  e0:   e8 00 00 00 00          callq  e5 <rust_crypto_aesni_setup_working_key_128+0xe5>
```

Fixes #295. Fixes #305.
