### PR TITLE
Fix warnings at build time due to mutable objects.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: rust
 rust:
     - nightly
-    - 1.0.0-beta
+    - 1.3.0

--- a/src/curve25519.rs
+++ b/src/curve25519.rs
@@ -335,15 +335,15 @@ impl Mul for Fe {
         let mut h8 = f0g8+f1g7_2 +f2g6   +f3g5_2 +f4g4   +f5g3_2 +f6g2   +f7g1_2 +f8g0   +f9g9_38;
         let mut h9 = f0g9+f1g8   +f2g7   +f3g6   +f4g5   +f5g4   +f6g3   +f7g2   +f8g1   +f9g0   ;
         let mut carry0;
-        let mut carry1;
-        let mut carry2;
-        let mut carry3;
+        let carry1;
+        let carry2;
+        let carry3;
         let mut carry4;
-        let mut carry5;
-        let mut carry6;
-        let mut carry7;
-        let mut carry8;
-        let mut carry9;
+        let carry5;
+        let carry6;
+        let carry7;
+        let carry8;
+        let carry9;
 
         /*
         |h0| <= (1.1*1.1*2^52*(1+19+19+19+19)+1.1*1.1*2^50*(38+38+38+38+38))
@@ -899,15 +899,15 @@ impl Fe {
         let mut h8 = f0f8_2+f1f7_4 +f2f6_2 +f3f5_4 +f4f4   +f9f9_38;
         let mut h9 = f0f9_2+f1f8_2 +f2f7_2 +f3f6_2 +f4f5_2;
         let mut carry0: i64;
-        let mut carry1: i64;
-        let mut carry2: i64;
-        let mut carry3: i64;
+        let carry1: i64;
+        let carry2: i64;
+        let carry3: i64;
         let mut carry4: i64;
-        let mut carry5: i64;
-        let mut carry6: i64;
-        let mut carry7: i64;
-        let mut carry8: i64;
-        let mut carry9: i64;
+        let carry5: i64;
+        let carry6: i64;
+        let carry7: i64;
+        let carry8: i64;
+        let carry9: i64;
 
         h0 += h0;
         h1 += h1;
@@ -1545,11 +1545,11 @@ pub fn sc_reduce(s: &mut [u8]) {
     let mut carry9: i64;
     let mut carry10: i64;
     let mut carry11: i64;
-    let mut carry12: i64;
-    let mut carry13: i64;
-    let mut carry14: i64;
-    let mut carry15: i64;
-    let mut carry16: i64;
+    let carry12: i64;
+    let carry13: i64;
+    let carry14: i64;
+    let carry15: i64;
+    let carry16: i64;
 
     s11 += s23 * 666643;
     s12 += s23 * 470296;
@@ -1838,12 +1838,12 @@ pub fn sc_muladd(s: &mut[u8], a: &[u8], b: &[u8], c: &[u8]) {
     let mut carry14: i64;
     let mut carry15: i64;
     let mut carry16: i64;
-    let mut carry17: i64;
-    let mut carry18: i64;
-    let mut carry19: i64;
-    let mut carry20: i64;
-    let mut carry21: i64;
-    let mut carry22: i64;
+    let carry17: i64;
+    let carry18: i64;
+    let carry19: i64;
+    let carry20: i64;
+    let carry21: i64;
+    let carry22: i64;
 
     s0 = c0 + a0*b0;
     s1 = c1 + a0*b1 + a1*b0;

--- a/src/hc128.rs
+++ b/src/hc128.rs
@@ -81,7 +81,7 @@ impl Hc128 {
         let dim_j511 : usize = (j.wrapping_sub(511)) & 0x1FF;
         let dim_j12 : usize = (j.wrapping_sub(12)) & 0x1FF;
 
-        let mut ret : u32;
+        let ret : u32;
 
         if self.cnt < 512 {
             self.p[j] = self.p[j].wrapping_add(self.p[dim_j3].rotate_right(10) ^ self.p[dim_j511].rotate_right(23)).wrapping_add(self.p[dim_j10].rotate_right(8));


### PR DESCRIPTION
Warnings output (Rust Compiler v1.3.0 @ Arch Linux):
```txt
Compiling gcc v0.3.18
   Compiling rustc-serialize v0.3.16
   Compiling winapi v0.2.4
   Compiling winapi-build v0.1.1
   Compiling libc v0.1.10
   Compiling advapi32-sys v0.1.2
   Compiling kernel32-sys v0.1.4
   Compiling rand v0.3.11
   Compiling time v0.1.32
   Compiling rust-crypto v0.2.31 (file:///home/samet/projects/rust/rust-crypto)
src/curve25519.rs:338:13: 338:23 warning: variable does not need to be mutable, #[warn(unused_mut)] on by default
src/curve25519.rs:338         let mut carry1;
                                  ^~~~~~~~~~
src/curve25519.rs:339:13: 339:23 warning: variable does not need to be mutable, #[warn(unused_mut)] on by default
src/curve25519.rs:339         let mut carry2;
                                  ^~~~~~~~~~
src/curve25519.rs:340:13: 340:23 warning: variable does not need to be mutable, #[warn(unused_mut)] on by default
src/curve25519.rs:340         let mut carry3;
                                  ^~~~~~~~~~
src/curve25519.rs:342:13: 342:23 warning: variable does not need to be mutable, #[warn(unused_mut)] on by default
src/curve25519.rs:342         let mut carry5;
                                  ^~~~~~~~~~
src/curve25519.rs:343:13: 343:23 warning: variable does not need to be mutable, #[warn(unused_mut)] on by default
src/curve25519.rs:343         let mut carry6;
                                  ^~~~~~~~~~
src/curve25519.rs:344:13: 344:23 warning: variable does not need to be mutable, #[warn(unused_mut)] on by default
src/curve25519.rs:344         let mut carry7;
                                  ^~~~~~~~~~
src/curve25519.rs:345:13: 345:23 warning: variable does not need to be mutable, #[warn(unused_mut)] on by default
src/curve25519.rs:345         let mut carry8;
                                  ^~~~~~~~~~
src/curve25519.rs:346:13: 346:23 warning: variable does not need to be mutable, #[warn(unused_mut)] on by default
src/curve25519.rs:346         let mut carry9;
                                  ^~~~~~~~~~
src/curve25519.rs:902:13: 902:23 warning: variable does not need to be mutable, #[warn(unused_mut)] on by default
src/curve25519.rs:902         let mut carry1: i64;
                                  ^~~~~~~~~~
src/curve25519.rs:903:13: 903:23 warning: variable does not need to be mutable, #[warn(unused_mut)] on by default
src/curve25519.rs:903         let mut carry2: i64;
                                  ^~~~~~~~~~
src/curve25519.rs:904:13: 904:23 warning: variable does not need to be mutable, #[warn(unused_mut)] on by default
src/curve25519.rs:904         let mut carry3: i64;
                                  ^~~~~~~~~~
src/curve25519.rs:906:13: 906:23 warning: variable does not need to be mutable, #[warn(unused_mut)] on by default
src/curve25519.rs:906         let mut carry5: i64;
                                  ^~~~~~~~~~
src/curve25519.rs:907:13: 907:23 warning: variable does not need to be mutable, #[warn(unused_mut)] on by default
src/curve25519.rs:907         let mut carry6: i64;
                                  ^~~~~~~~~~
src/curve25519.rs:908:13: 908:23 warning: variable does not need to be mutable, #[warn(unused_mut)] on by default
src/curve25519.rs:908         let mut carry7: i64;
                                  ^~~~~~~~~~
src/curve25519.rs:909:13: 909:23 warning: variable does not need to be mutable, #[warn(unused_mut)] on by default
src/curve25519.rs:909         let mut carry8: i64;
                                  ^~~~~~~~~~
src/curve25519.rs:910:13: 910:23 warning: variable does not need to be mutable, #[warn(unused_mut)] on by default
src/curve25519.rs:910         let mut carry9: i64;
                                  ^~~~~~~~~~
src/curve25519.rs:1548:9: 1548:20 warning: variable does not need to be mutable, #[warn(unused_mut)] on by default
src/curve25519.rs:1548     let mut carry12: i64;
                               ^~~~~~~~~~~
src/curve25519.rs:1549:9: 1549:20 warning: variable does not need to be mutable, #[warn(unused_mut)] on by default
src/curve25519.rs:1549     let mut carry13: i64;
                               ^~~~~~~~~~~
src/curve25519.rs:1550:9: 1550:20 warning: variable does not need to be mutable, #[warn(unused_mut)] on by default
src/curve25519.rs:1550     let mut carry14: i64;
                               ^~~~~~~~~~~
src/curve25519.rs:1551:9: 1551:20 warning: variable does not need to be mutable, #[warn(unused_mut)] on by default
src/curve25519.rs:1551     let mut carry15: i64;
                               ^~~~~~~~~~~
src/curve25519.rs:1552:9: 1552:20 warning: variable does not need to be mutable, #[warn(unused_mut)] on by default
src/curve25519.rs:1552     let mut carry16: i64;
                               ^~~~~~~~~~~
src/curve25519.rs:1841:9: 1841:20 warning: variable does not need to be mutable, #[warn(unused_mut)] on by default
src/curve25519.rs:1841     let mut carry17: i64;
                               ^~~~~~~~~~~
src/curve25519.rs:1842:9: 1842:20 warning: variable does not need to be mutable, #[warn(unused_mut)] on by default
src/curve25519.rs:1842     let mut carry18: i64;
                               ^~~~~~~~~~~
src/curve25519.rs:1843:9: 1843:20 warning: variable does not need to be mutable, #[warn(unused_mut)] on by default
src/curve25519.rs:1843     let mut carry19: i64;
                               ^~~~~~~~~~~
src/curve25519.rs:1844:9: 1844:20 warning: variable does not need to be mutable, #[warn(unused_mut)] on by default
src/curve25519.rs:1844     let mut carry20: i64;
                               ^~~~~~~~~~~
src/curve25519.rs:1845:9: 1845:20 warning: variable does not need to be mutable, #[warn(unused_mut)] on by default
src/curve25519.rs:1845     let mut carry21: i64;
                               ^~~~~~~~~~~
src/curve25519.rs:1846:9: 1846:20 warning: variable does not need to be mutable, #[warn(unused_mut)] on by default
src/curve25519.rs:1846     let mut carry22: i64;

```