### PR TITLE
Set 'sudo: false' in the .travis.yml file to take advantage of newer Travis build infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,4 @@ language: rust
 rust:
     - nightly
     - stable
+sudo: false


### PR DESCRIPTION
Set 'sudo: false' in the .travis.yml file to take advantage of newer Travis build infrastructure