### PR TITLE
Implement assembly routines for MSVC based toolchains

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -6,9 +6,22 @@
 
 extern crate gcc;
 
+use std::env;
+
 fn main() {
-    gcc::compile_library(
-        "lib_rust_crypto_helpers.a",
-        &["src/util_helpers.c", "src/aesni_helpers.c"]);
+    let target = env::var("TARGET").unwrap();
+    if target.contains("msvc") {
+        let mut config = gcc::Config::new();
+        config.file("src/util_helpers.asm");
+        config.file("src/aesni_helpers.asm");
+        if target.contains("x86_64") {
+            config.define("X64", None);
+        }
+        config.compile("lib_rust_crypto_helpers.a");
+    } else {
+        gcc::compile_library(
+            "lib_rust_crypto_helpers.a",
+            &["src/util_helpers.c", "src/aesni_helpers.c"]);
+    }
 }
 

--- a/src/aesni.rs
+++ b/src/aesni.rs
@@ -7,6 +7,7 @@
 use aes::KeySize;
 use aes::KeySize::{KeySize128, KeySize192, KeySize256};
 use symmetriccipher::{BlockEncryptor, BlockDecryptor};
+use util::supports_aesni;
 
 #[derive(Copy)]
 pub struct AesNiEncryptor {
@@ -29,6 +30,11 @@ type RoundSetupInfo = (u8, fn(&[u8], KeyType, &mut [u8]));
 
 impl AesNiEncryptor {
     pub fn new(key_size: KeySize, key: &[u8]) -> AesNiEncryptor {
+        if !supports_aesni() {
+            panic!("AES-NI not supported on this architecture. If you are \
+                using the MSVC toolchain, this is because the AES-NI method's \
+                have not been ported, yet");
+        }
         let (rounds, setup_function): RoundSetupInfo = match key_size {
             KeySize128 => (10, setup_working_key_aesni_128),
             KeySize192 => (12, setup_working_key_aesni_192),
@@ -45,6 +51,11 @@ impl AesNiEncryptor {
 
 impl AesNiDecryptor {
     pub fn new(key_size: KeySize, key: &[u8]) -> AesNiDecryptor {
+        if !supports_aesni() {
+            panic!("AES-NI not supported on this architecture. If you are \
+                using the MSVC toolchain, this is because the AES-NI method's \
+                have not been ported, yet");
+        }
         let (rounds, setup_function): RoundSetupInfo = match key_size {
             KeySize128 => (10, setup_working_key_aesni_128),
             KeySize192 => (12, setup_working_key_aesni_192),

--- a/src/aesni_helpers.asm
+++ b/src/aesni_helpers.asm
@@ -1,0 +1,34 @@
+ifndef X64
+.686p
+.XMM
+.model flat, C
+endif
+
+.code
+
+rust_crypto_aesni_aesimc PROC public
+  ret
+rust_crypto_aesni_aesimc ENDP
+
+rust_crypto_aesni_setup_working_key_128 PROC public
+  ret
+rust_crypto_aesni_setup_working_key_128 ENDP
+
+rust_crypto_aesni_setup_working_key_192 PROC public
+  ret
+rust_crypto_aesni_setup_working_key_192 ENDP
+
+rust_crypto_aesni_setup_working_key_256 PROC public
+  ret
+rust_crypto_aesni_setup_working_key_256 ENDP
+
+rust_crypto_aesni_encrypt_block PROC public
+  ret
+rust_crypto_aesni_encrypt_block ENDP
+
+rust_crypto_aesni_decrypt_block PROC public
+  ret
+rust_crypto_aesni_decrypt_block ENDP
+
+end
+

--- a/src/util.rs
+++ b/src/util.rs
@@ -43,8 +43,6 @@ pub fn secure_memset(dst: &mut [u8], val: u8) {
 pub fn fixed_time_eq(lhs: &[u8], rhs: &[u8]) -> bool {
     if lhs.len() != rhs.len() {
         false
-    } else if lhs.len() == 0 {
-        true
     } else {
         let count = lhs.len() as libc::size_t;
 

--- a/src/util_helpers.asm
+++ b/src/util_helpers.asm
@@ -1,0 +1,126 @@
+ifndef X64
+.686p
+.XMM
+.model flat, C
+endif
+
+.code
+
+rust_crypto_util_supports_aesni PROC public
+  ; Return false since the AES-NI function have not been
+  ; converted to assembly
+  xor eax, eax
+  ret
+rust_crypto_util_supports_aesni ENDP
+
+; The rust_crypto_util_fixed_time_eq_asm for X86-64
+ifdef X64
+rust_crypto_util_fixed_time_eq_asm PROC public lhs:QWORD, rhs:QWORD, count:QWORD
+  ; lhs is in RCX
+  ; rhs is in RDX
+  ; count is in R8
+
+  ; set the return value initially to 0
+  xor eax, eax
+
+  test r8, r8
+  jz DONE
+
+  BEGIN:
+
+  mov r10b, [rcx]
+  xor r10b, [rdx]
+  or al, r10b
+
+  inc rcx
+  inc rdx
+  dec r8
+  jnz BEGIN
+
+  DONE:
+
+  ret
+rust_crypto_util_fixed_time_eq_asm ENDP
+endif
+
+; The rust_crypto_util_fixed_time_eq_asm for X86 (32-bit)
+ifndef X64
+rust_crypto_util_fixed_time_eq_asm PROC public lhs:DWORD, rhs:DWORD, count:DWORD
+  push ebx
+  push esi
+
+  mov ecx, lhs
+  mov edx, rhs
+  mov esi, count
+
+  xor eax, eax
+
+  test esi, esi
+  jz DONE
+
+  BEGIN:
+
+  mov bl, [ecx]
+  xor bl, [edx]
+  or al, bl
+
+  inc ecx
+  inc edx
+  dec esi
+  jnz BEGIN
+
+  DONE:
+
+  pop esi
+  pop ebx
+
+  ret
+rust_crypto_util_fixed_time_eq_asm ENDP
+endif
+
+ifdef X64
+rust_crypto_util_secure_memset PROC public dst:QWORD, val:BYTE, count:QWORD
+  ; dst is in RCX
+  ; val is in RDX
+  ; count is in R8
+
+  test r8, r8
+  jz DONE
+
+  BEGIN:
+
+  mov [rcx], dl
+  inc rcx
+  dec r8
+  jnz BEGIN
+
+  DONE:
+
+  ret
+rust_crypto_util_secure_memset ENDP
+endif
+
+ifndef X64
+rust_crypto_util_secure_memset PROC public dst:DWORD, val:BYTE, count:DWORD
+  mov eax, dst
+  mov cl, val
+  mov edx, count
+
+  test edx, edx
+  jz DONE
+
+  BEGIN:
+
+  mov [eax], cl
+  inc eax
+  dec edx
+  jnz BEGIN
+
+  DONE:
+
+  ret
+rust_crypto_util_secure_memset ENDP
+endif
+
+end
+

--- a/src/util_helpers.c
+++ b/src/util_helpers.c
@@ -97,6 +97,6 @@ uint32_t rust_crypto_util_fixed_time_eq_asm(uint8_t* lhsp, uint8_t* rhsp, size_t
 
 void rust_crypto_util_secure_memset(uint8_t* dst, uint8_t val, size_t count) {
     memset(dst, val, count);
-    asm("" : : "g" (dst) : "memory");
+    asm volatile("" : : "g" (dst) : "memory");
 }
 

--- a/src/util_helpers.c
+++ b/src/util_helpers.c
@@ -46,6 +46,9 @@ uint32_t rust_crypto_util_supports_aesni() {
 
 #if defined(__i386__) || defined(__x86_64__)
 uint32_t rust_crypto_util_fixed_time_eq_asm(uint8_t* lhsp, uint8_t* rhsp, size_t count) {
+    if (count == 0) {
+        return 1;
+    }
     uint8_t result = 0;
     asm(
         " \
@@ -71,6 +74,9 @@ uint32_t rust_crypto_util_fixed_time_eq_asm(uint8_t* lhsp, uint8_t* rhsp, size_t
 
 #ifdef __arm__
 uint32_t rust_crypto_util_fixed_time_eq_asm(uint8_t* lhsp, uint8_t* rhsp, size_t count) {
+    if (count == 0) {
+        return 1;
+    }
     uint8_t result = 0;
     asm(
         " \


### PR DESCRIPTION
Resolves issuing building with the MSVC based toolchain. The issue was that the build requires compiling some C files with inline assembly in the GCC format which is, unsurprisingly, not supported by MSVC. Additionally, MSVC doesn't support inline assembly at all on x86_64. So, the fixed time comparison and secure memory set routines have been ported to MASM assembly and the `build.rs` file has been updated to build those files instead of the C files with inline assembly used by GCC.

Significantly, the AES-NI implementation of AES is *not* ported. Any attempt to use that implementation will cause a `panic!()` which isn't a great solution, but its better than not compiling at all. Also, if using the functions in the `aes` module to dynamically pick the best AES implementation, it won't be a problem at all since the AES-NI implementation won't ever be picked when compiled for the MSVC backed targets.

In theory, this should work with the 32-bit MSVC target. However, it hasn't been tested much in this configuration. The main issue is that Rust doesn't support stack unwinding on 32-bit MSVC targets which makes the test suite fail. The 64-bit MSVC target supports unwinding and passes all tests with these changes.

Fixes #324
