### PR TITLE
Use Inline assembly for msvc target from non-windows host

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -10,7 +10,8 @@ use std::env;
 
 fn main() {
     let target = env::var("TARGET").unwrap();
-    if target.contains("msvc") {
+    let host = env::var("HOST").unwrap();
+    if target.contains("msvc") && host.contains("windows") {
         let mut config = gcc::Config::new();
         config.file("src/util_helpers.asm");
         config.file("src/aesni_helpers.asm");


### PR DESCRIPTION
When cross-compiling for msvc from a non-windows host, inline assembly is typically supported (for example via clang or clang-cl). Given that clang also doesn't support masm or have ml.exe compatibility, it's Most Unexceptional to use the C implementations of `util_helpers` and `aesni_helpers`.