### PR TITLE
bcrypt: Fix overflow when cost == 31.

### DIFF
--- a/src/bcrypt.rs
+++ b/src/bcrypt.rs
@@ -9,10 +9,11 @@ use cryptoutil::{write_u32_be};
 use step_by::RangeExt;
 
 fn setup(cost: u32, salt: &[u8], key: &[u8]) -> Blowfish {
+    assert!(cost < 32);
     let mut state = Blowfish::init_state();
     
     state.salted_expand_key(salt, key);
-    for _ in 0..1 << cost {
+    for _ in 0..1u32 << cost {
         state.expand_key(key);
         state.expand_key(salt);
     }


### PR DESCRIPTION
Previously, passing a cost of 31 would cause the shift operator to overflow, making it equivalent to `cost = 0`.  Fixes #332.