### PR TITLE
Documentation upload

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ sudo: false
 os:
   - linux
   - osx
-
 addons:
   apt:
     packages:
@@ -13,7 +12,7 @@ addons:
       - libdw-dev
       - binutils-dev
 
-# run builds for all the trains
+# Run builds for all the supported trains
 rust:
   - nightly
   - beta
@@ -25,7 +24,7 @@ rust:
   - 1.4.0
   - 1.3.0
 
-# load travis-cargo
+# Load travis-cargo
 before_script:
   - |
       if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
@@ -33,30 +32,31 @@ before_script:
       export PATH=$HOME/.local/bin:$PATH
       fi
 
-# the main build
+# The main build
 script:
   - |
       if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
       travis-cargo build &&
       travis-cargo test &&
-      travis-cargo bench &&
-      travis-cargo --only stable doc;
+      travis-cargo bench;
       fi
   - |
       if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-      cargo build -v &&
+      cargo build &&
       cargo test &&
       cargo bench;
       fi
 
+# Send coverage reports and upload docs
 after_success:
   - |
-      if [["$TRAVIS_OS_NAME" == "linux"]]; then
-      travis-cargo --only stable doc-upload;
+      if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+      travis-cargo --only stable doc &&
+      travis-cargo --only stable doc-upload --branch develop;
       fi
   - |
-      if [["$TRAVIS_OS_NAME" == "linux" && "$TRAVIS_RUST_VERSION" == "stable"]]; then
-      travis-cargo coveralls --no-sudo --verify;
+      if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+      travis-cargo --only stable coveralls --no-sudo --verify;
       fi
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,6 @@ rust:
   - 1.5.0
   - 1.4.0
   - 1.3.0
-  - 1.2.0
-  - 1.1.0
-  - 1.0.0
 
 # load travis-cargo
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,43 @@
 language: rust
-rust:
-    - nightly
-    - stable
 sudo: false
+addons:
+  apt:
+    packages:
+      - libcurl4-openssl-dev
+      - libelf-dev
+      - libdw-dev
+      - binutils-dev
+
+# run builds for all the trains
+rust:
+  - nightly
+  - beta
+  - stable
+  - 1.7.0
+  - 1.6.0
+  - 1.5.0
+  - 1.4.0
+  - 1.3.0
+  - 1.2.0
+  - 1.1.0
+  - 1.0.0
+
+# load travis-cargo
+before_script:
+  - |
+      pip install 'travis-cargo<0.2' --user &&
+      export PATH=$HOME/.local/bin:$PATH
+
+# the main build
+script:
+  - |
+      travis-cargo build &&
+      travis-cargo test &&
+      travis-cargo --only stable doc
+after_success:
+  - travis-cargo --only stable doc-upload
+  - travis-cargo coveralls --no-sudo --verify
+
+env:
+  global:
+    - TRAVIS_CARGO_NIGHTLY_FEATURE=""

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: rust
+dist: trusty
 sudo: false
+os:
+  - linux
+  - osx
+
 addons:
   apt:
     packages:
@@ -13,6 +18,7 @@ rust:
   - nightly
   - beta
   - stable
+  - 1.8.0
   - 1.7.0
   - 1.6.0
   - 1.5.0
@@ -22,18 +28,36 @@ rust:
 # load travis-cargo
 before_script:
   - |
+      if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
       pip install 'travis-cargo<0.2' --user &&
       export PATH=$HOME/.local/bin:$PATH
+      fi
 
 # the main build
 script:
   - |
+      if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
       travis-cargo build &&
       travis-cargo test &&
-      travis-cargo --only stable doc
+      travis-cargo bench &&
+      travis-cargo --only stable doc;
+      fi
+  - |
+      if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      cargo build -v &&
+      cargo test &&
+      cargo bench;
+      fi
+
 after_success:
-  - travis-cargo --only stable doc-upload
-  - travis-cargo coveralls --no-sudo --verify
+  - |
+      if [["$TRAVIS_OS_NAME" == "linux"]]; then
+      travis-cargo --only stable doc-upload;
+      fi
+  - |
+      if [["$TRAVIS_OS_NAME" == "linux" && "$TRAVIS_RUST_VERSION" == "stable"]]; then
+      travis-cargo coveralls --no-sudo --verify;
+      fi
 
 env:
   global:


### PR DESCRIPTION
This would implement #334. The only action needed would be to add a token in one account with ability to push to the repo and to add it as `GH_TOKEN` environment variable in Travis. Docs and coverage report will be uploaded automatically. For coverage report you need a coveralls account.

Also, I added tests to compile from Rust 1.3.0 to Rust nightly (1.3.0 is the lowest version compatible with Rust-crypto). Docs will be uploaded to a branch named `gh-pages`. An example here: https://github.com/FractalGlobal/ntru-rs
