### PR TITLE
Upgraded libc to 0.2 branch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,7 @@ with-bench = []
 gcc = "^0.3"
 
 [dependencies]
-libc = "^0.1"
+libc = "^0.2"
 time = "^0.1"
 rand = "^0.3"
 rustc-serialize = "^0.3"
-


### PR DESCRIPTION
This should probably carry a bump in the minor version of the library due to libc 0.1 to 0.2 incompatibilities when building.