### PR TITLE
Fix cross compilation error

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -31,7 +31,7 @@ fn main() {
                 // GCC doesn't like some of the assembly that we use on that
                 // platform.
                 cfg.compiler(Path::new("clang"));
-            } else {
+            } else if target == host {
                 cfg.compiler(Path::new("cc"));
             }
         }


### PR DESCRIPTION
Current build script overrides target compiler and this cause problems with cross-compiling process. For example when our host is x86_64-unknown-linux-gnu and target arm-unknown-linux-gnueabi compilation will fail with following error:

```
failed to run custom build command for `rust-crypto v0.2.35`
Process didn't exit successfully: `/home/mk/git/box/server/target/release/build/rust-crypto-6acb19580f9fa57f/build-script-build` (exit code: 101)
--- stdout
TARGET = Some("arm-unknown-linux-gnueabi")
OPT_LEVEL = Some("3")
PROFILE = Some("release")
TARGET = Some("arm-unknown-linux-gnueabi")
debug=false opt-level=3
TARGET = Some("arm-unknown-linux-gnueabi")
HOST = Some("x86_64-unknown-linux-gnu")
CFLAGS_arm-unknown-linux-gnueabi = None
CFLAGS_arm_unknown_linux_gnueabi = None
TARGET_CFLAGS = None
CFLAGS = None
running: "cc" "-O3" "-ffunction-sections" "-fdata-sections" "-fPIC" "-march=armv6" "-marm" "-o" "/home/mk/git/box/server/target/arm-unknown-linux-gnueabi/release/build/rust-crypto-6acb19580f9fa57f/out/src/util_helpers.o" "-c" "src/util_helpers.c"
ExitStatus(ExitStatus(256))


command did not execute successfully, got: exit code: 1



--- stderr
gcc-4.8.real: error: unrecognized command line option ‘-marm’
thread '<main>' panicked at 'explicit panic', /home/mk/.multirust/toolchains/1.7.0/cargo/registry/src/github.com-88ac128001ac3a9a/gcc-0.3.26/src/lib.rs:818
```

The proposition here is leaving currently defined compiler name only if host is different from target and replacing it with "cc" otherwise.