### PR TITLE
Windows tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,13 +20,11 @@ environment:
   - TARGET: 1.8.0-i686-pc-windows-gnu
     MSYS_BITS: 32
   - TARGET: 1.7.0-x86_64-pc-windows-msvc
-  - TARGET: 1.7.0-i686-pc-windows-msvc
   - TARGET: 1.7.0-x86_64-pc-windows-gnu
     MSYS_BITS: 64
   - TARGET: 1.7.0-i686-pc-windows-gnu
     MSYS_BITS: 32
   - TARGET: 1.6.0-x86_64-pc-windows-msvc
-  - TARGET: 1.6.0-i686-pc-windows-msvc
   - TARGET: 1.6.0-x86_64-pc-windows-gnu
     MSYS_BITS: 64
   - TARGET: 1.6.0-i686-pc-windows-gnu

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,64 @@
+clone_depth: 50
+environment:
+  matrix:
+  - TARGET: nightly-x86_64-pc-windows-msvc
+  - TARGET: nightly-i686-pc-windows-msvc
+  - TARGET: nightly-x86_64-pc-windows-gnu
+    MSYS_BITS: 64
+  - TARGET: nightly-i686-pc-windows-gnu
+    MSYS_BITS: 32
+  - TARGET: beta-x86_64-pc-windows-msvc
+  - TARGET: beta-i686-pc-windows-mcvc
+  - TARGET: beta-x86_64-pc-windows-gnu
+    MSYS_BITS: 64
+  - TARGET: beta-i686-pc-windows-gnu
+    MSYS_BITS: 32
+  - TARGET: 1.8.0-x86_64-pc-windows-msvc
+  - TARGET: 1.8.0-i686-pc-windows-msvc
+  - TARGET: 1.8.0-x86_64-pc-windows-gnu
+    MSYS_BITS: 64
+  - TARGET: 1.8.0-i686-pc-windows-gnu
+    MSYS_BITS: 32
+  - TARGET: 1.7.0-x86_64-pc-windows-msvc
+  - TARGET: 1.7.0-i686-pc-windows-msvc
+  - TARGET: 1.7.0-x86_64-pc-windows-gnu
+    MSYS_BITS: 64
+  - TARGET: 1.7.0-i686-pc-windows-gnu
+    MSYS_BITS: 32
+  - TARGET: 1.6.0-x86_64-pc-windows-msvc
+  - TARGET: 1.6.0-i686-pc-windows-msvc
+  - TARGET: 1.6.0-x86_64-pc-windows-gnu
+    MSYS_BITS: 64
+  - TARGET: 1.6.0-i686-pc-windows-gnu
+    MSYS_BITS: 32
+  - TARGET: 1.5.0-x86_64-pc-windows-msvc
+  - TARGET: 1.5.0-i686-pc-windows-msvc
+  - TARGET: 1.5.0-x86_64-pc-windows-gnu
+    MSYS_BITS: 64
+  - TARGET: 1.5.0-i686-pc-windows-gnu
+    MSYS_BITS: 32
+  - TARGET: 1.4.0-x86_64-pc-windows-msvc
+  - TARGET: 1.4.0-i686-pc-windows-msvc
+  - TARGET: 1.4.0-x86_64-pc-windows-gnu
+    MSYS_BITS: 64
+  - TARGET: 1.4.0-i686-pc-windows-gnu
+    MSYS_BITS: 32
+  - TARGET: 1.3.0-x86_64-pc-windows-msvc
+  - TARGET: 1.3.0-i686-pc-windows-msvc
+  - TARGET: 1.3.0-x86_64-pc-windows-gnu
+    MSYS_BITS: 64
+  - TARGET: 1.3.0-i686-pc-windows-gnu
+    MSYS_BITS: 32
+install:
+  - git submodule update --init --recursive
+  - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-${env:TARGET}.exe" -FileName "rust-install.exe"
+  - ps: .\rust-install.exe /VERYSILENT /NORESTART /DIR="C:\rust" | Out-Null
+  - ps: $env:PATH="$env:PATH;C:\rust\bin"
+  - if defined MSYS_BITS set PATH=C:\msys64\mingw%MSYS_BITS%\bin;C:\msys64\usr\bin;%PATH%
+  - rustc -vV
+  - cargo -vV
+build_script:
+  - cargo build
+  - cargo package
+test_script:
+  - cargo test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ environment:
   - TARGET: nightly-i686-pc-windows-gnu
     MSYS_BITS: 32
   - TARGET: beta-x86_64-pc-windows-msvc
-  - TARGET: beta-i686-pc-windows-mcvc
+  - TARGET: beta-i686-pc-windows-msvc
   - TARGET: beta-x86_64-pc-windows-gnu
     MSYS_BITS: 64
   - TARGET: beta-i686-pc-windows-gnu

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,23 +31,13 @@ environment:
     MSYS_BITS: 64
   - TARGET: 1.6.0-i686-pc-windows-gnu
     MSYS_BITS: 32
-  - TARGET: 1.5.0-x86_64-pc-windows-msvc
-  - TARGET: 1.5.0-i686-pc-windows-msvc
   - TARGET: 1.5.0-x86_64-pc-windows-gnu
     MSYS_BITS: 64
   - TARGET: 1.5.0-i686-pc-windows-gnu
     MSYS_BITS: 32
-  - TARGET: 1.4.0-x86_64-pc-windows-msvc
-  - TARGET: 1.4.0-i686-pc-windows-msvc
   - TARGET: 1.4.0-x86_64-pc-windows-gnu
     MSYS_BITS: 64
   - TARGET: 1.4.0-i686-pc-windows-gnu
-    MSYS_BITS: 32
-  - TARGET: 1.3.0-x86_64-pc-windows-msvc
-  - TARGET: 1.3.0-i686-pc-windows-msvc
-  - TARGET: 1.3.0-x86_64-pc-windows-gnu
-    MSYS_BITS: 64
-  - TARGET: 1.3.0-i686-pc-windows-gnu
     MSYS_BITS: 32
 install:
   - git submodule update --init --recursive


### PR DESCRIPTION
Added Windows tests in Appveyor. Only targets that pass the tests have been added. That's all 4 targets for 1.8.0, but less for prior versions (i686 MSVC target wasn't working until 1.8.0 and no MSVC was working until 1.6.0, while in 1.4.0 not even the i686 GNU build was working).

You can see the results of the build here: https://ci.appveyor.com/project/Razican/rust-crypto/build/1.0.5