### PR TITLE
Implement Copy and Clone for all Digest impls

### DIFF
--- a/src/cryptoutil.rs
+++ b/src/cryptoutil.rs
@@ -461,10 +461,13 @@ impl FixedBuffer64 {
 impl_fixed_buffer!(FixedBuffer64, 64);
 
 /// A fixed size buffer of 128 bytes useful for cryptographic operations.
+#[derive(Copy)]
 pub struct FixedBuffer128 {
     buffer: [u8; 128],
     buffer_idx: usize,
 }
+
+impl Clone for FixedBuffer128 { fn clone(&self) -> FixedBuffer128 { *self } }
 
 impl FixedBuffer128 {
     /// Create a new buffer

--- a/src/md5.rs
+++ b/src/md5.rs
@@ -14,6 +14,7 @@ use step_by::RangeExt;
 
 
 // A structure that represents that state of a digest computation for the MD5 digest function
+#[derive(Clone, Copy)]
 struct Md5State {
     s0: u32,
     s1: u32,
@@ -151,6 +152,7 @@ static C4: [u32; 16] = [
 
 
 /// The MD5 Digest algorithm
+#[derive(Clone, Copy)]
 pub struct Md5 {
     length_bytes: u64,
     buffer: FixedBuffer64,

--- a/src/sha2.rs
+++ b/src/sha2.rs
@@ -644,6 +644,7 @@ pub fn sha512_digest_block(state: &mut [u64; 8], block: &[u8/*; 128*/]) {
 
 // A structure that represents that state of a digest computation for the SHA-2 512 family
 // of digest functions
+#[derive(Copy, Clone)]
 struct Engine512State {
     h: [u64; 8]
 }
@@ -704,6 +705,7 @@ pub const K64X2: [u64x2; 40] = [
 
 // A structure that keeps track of the state of the Sha-512 operation and contains the logic
 // necessary to perform the final calculations.
+#[derive(Copy, Clone)]
 struct Engine512 {
     length_bits: (u64, u64),
     buffer: FixedBuffer128,
@@ -757,6 +759,7 @@ impl Engine512 {
 
 
 /// The SHA-512 hash algorithm with the SHA-512 initial hash value.
+#[derive(Copy, Clone)]
 pub struct Sha512 {
     engine: Engine512
 }
@@ -812,6 +815,7 @@ static H512: [u64; STATE_LEN] = [
 
 
 /// The SHA-512 hash algorithm with the SHA-384 initial hash value. The result is truncated to 384 bits.
+#[derive(Copy, Clone)]
 pub struct Sha384 {
     engine: Engine512
 }
@@ -865,6 +869,7 @@ static H384: [u64; STATE_LEN] = [
 
 
 /// The SHA-512 hash algorithm with the SHA-512/256 initial hash value. The result is truncated to 256 bits.
+#[derive(Clone, Copy)]
 pub struct Sha512Trunc256 {
     engine: Engine512
 }
@@ -916,6 +921,7 @@ static H512_TRUNC_256: [u64; STATE_LEN] = [
 
 
 /// The SHA-512 hash algorithm with the SHA-512/224 initial hash value. The result is truncated to 224 bits.
+#[derive(Clone, Copy)]
 pub struct Sha512Trunc224 {
     engine: Engine512
 }

--- a/src/whirlpool.rs
+++ b/src/whirlpool.rs
@@ -39,6 +39,7 @@ use std::mem::uninitialized;
 use cryptoutil::{write_u64_be, FixedBuffer64, FixedBuffer};
 use digest::Digest;
 
+#[derive(Clone, Copy)]
 pub struct Whirlpool {
     bit_length: [u8; 32],
     buffer: FixedBuffer64,


### PR DESCRIPTION
This brings all hashing algorithms up to feature parity.
    
Closes #338
