### PR TITLE
Added BLAKE2s, capitalized BLAKE2b in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ it will support even more in the future. Currently supported algorithms include:
 
 * AES
 * Bcrypt
-* Blake2B
+* BLAKE2b
+* BLAKE2s
 * Blowfish
 * ChaCha20
 * Curve25519


### PR DESCRIPTION
Hi, I noticed BLAKE2s is also implemented. I added it to the readme and capitalized the algorithm names according to blake2.net.
