### PR TITLE
bcrypt_pbkdf: reduce amount of copying done

### DIFF
--- a/src/bcrypt_pbkdf.rs
+++ b/src/bcrypt_pbkdf.rs
@@ -73,12 +73,12 @@ pub fn bcrypt_pbkdf(password: &[u8], salt: &[u8], rounds: u32, output: &mut [u8]
             for i in 0..out.len() {
                 out[i] ^= tmp[i];
             }
+        }
 
-            for i in 0..out.len() {
-                let idx = i * nblocks + (block-1);
-                if idx < output.len() {
-                    output[idx] = out[i];
-                }
+        for i in 0..out.len() {
+            let idx = i * nblocks + (block-1);
+            if idx < output.len() {
+                output[idx] = out[i];
             }
         }
     }


### PR DESCRIPTION
The final copy into |output| does not need to be done until all the
rounds for the block are complete. Otherwise it is continuously
overwritten each round.