### PR TITLE
fix unicode in aessafe docs

### DIFF
--- a/src/aessafe.rs
+++ b/src/aessafe.rs
@@ -111,10 +111,10 @@ finite field which allows for efficient computation of the AES S-Boxes. See [7] 
 [2] - "Software mitigations to hedge AES against cache-based software side channel vulnerabilities".
       Ernie Brickell, et al. http://eprint.iacr.org/2006/052.pdf.
 [3] - "Cache Attacks and Countermeasures: the Case of AES (Extended Version)".
-      Dag Arne Osvik, et al. tau.ac.il/~tromer/papers/cache.pdf‎.
+      Dag Arne Osvik, et al. tau.ac.il/~tromer/papers/cache.pdf.
 [4] - "A Fast New DES Implementation in Software". Eli Biham.
       http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.52.5429&rep=rep1&type=pdf.
-[5] - "Faster and Timing-Attack Resistant AES-GCM". Emilia K ̈asper and Peter Schwabe.
+[5] - "Faster and Timing-Attack Resistant AES-GCM". Emilia Käsper and Peter Schwabe.
       http://www.chesworkshop.org/ches2009/presentations/01_Session_1/CHES2009_ekasper.pdf.
 [6] - "FAST AES DECRYPTION". Vinit Azad. http://webcache.googleusercontent.com/
       search?q=cache:ld_f8pSgURcJ:csusdspace.calstate.edu/bitstream/handle/10211.9/1224/


### PR DESCRIPTION
This commit removes a (non-visible) U+200E character in one line, and replaces `̈a` by `ä` in another line of the `aessafe.rs` documentation.
