### PR TITLE
Note that sha3 (keccak) is supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,5 +69,6 @@ it will support even more in the future. Currently supported algorithms include:
 * Scrypt
 * Sha1
 * Sha2 (All fixed output size variants)
+* Sha3
 * Sosemanuk
 * Whirlpool


### PR DESCRIPTION
I noticed that sha3 is supported as of https://github.com/DaGenix/rust-crypto/pull/346, but not yet mentioned in the readme.