### PR TITLE
Replace time with std::time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,5 @@ gcc = "^0.3"
 
 [dependencies]
 libc = "^0.2"
-time = "^0.1"
 rand = "^0.3"
 rustc-serialize = "^0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,6 @@
 
 extern crate rand;
 extern crate rustc_serialize as serialize;
-extern crate time;
 extern crate libc;
 
 #[cfg(all(test, feature = "with-bench"))]


### PR DESCRIPTION
If it's desirable to keep last_reseed_time at 8 bytes then instead of initializing last_reseed_time as None it could be set to Instant::now() - Duration::from_millis(200)