### PR TITLE
Use correct slice indices in RefReadBuffer.peek_next()

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -89,7 +89,7 @@ impl <'a> ReadBuffer for RefReadBuffer<'a> {
     }
     fn reset(&mut self) { self.pos = 0; }
 
-    fn peek_next(&self, count: usize) -> &[u8] { &self.buff[self.pos..count] }
+    fn peek_next(&self, count: usize) -> &[u8] { &self.buff[self.pos..self.pos + count] }
 
     fn take_next(&mut self, count: usize) -> &[u8] {
         let r = &self.buff[self.pos..self.pos + count];


### PR DESCRIPTION
Currently, if one wants to peek at `x` bytes in buffer `b`, one has to use
`b.peek_next(b.capacity() - b.remaining() + x)`
This commit changes the slice indices to match RefReadBuffer.take_next()