### PR TITLE
Fix gcc crate name. It's now cc.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ name = "crypto"
 with-bench = []
 
 [build-dependencies]
-gcc = "^0.3"
+cc = "^1.0"
 
 [dependencies]
 libc = "^0.2"

--- a/build.rs
+++ b/build.rs
@@ -4,7 +4,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-extern crate gcc;
+extern crate cc;
 
 use std::env;
 use std::path::Path;
@@ -13,29 +13,29 @@ fn main() {
     let target = env::var("TARGET").unwrap();
     let host = env::var("HOST").unwrap();
     if target.contains("msvc") && host.contains("windows") {
-        let mut config = gcc::Config::new();
-        config.file("src/util_helpers.asm");
-        config.file("src/aesni_helpers.asm");
+        let mut build = cc::Build::new();
+        build.file("src/util_helpers.asm");
+        build.file("src/aesni_helpers.asm");
         if target.contains("x86_64") {
-            config.define("X64", None);
+            build.define("X64", None);
         }
-        config.compile("lib_rust_crypto_helpers.a");
+        build.compile("lib_rust_crypto_helpers.a");
     }
     else {
-        let mut cfg = gcc::Config::new();
-        cfg.file("src/util_helpers.c");
-        cfg.file("src/aesni_helpers.c");
+        let mut build = cc::Build::new();
+        build.file("src/util_helpers.c");
+        build.file("src/aesni_helpers.c");
         if env::var_os("CC").is_none() {
             if host.contains("openbsd") {
                 // Use clang on openbsd since there have been reports that
                 // GCC doesn't like some of the assembly that we use on that
                 // platform.
-                cfg.compiler(Path::new("clang"));
+                build.compiler(Path::new("clang"));
             } else if target == host {
-                cfg.compiler(Path::new("cc"));
+                build.compiler(Path::new("cc"));
             }
         }
-        cfg.compile("lib_rust_crypto_helpers.a");
+        build.compile("lib_rust_crypto_helpers.a");
     }
 }
 


### PR DESCRIPTION
Also, the gcc's Config type is renamed to Build in cc.

Ref. https://users.rust-lang.org/t/the-gcc-crate-is-now-cc-1-0-0/12961