### PR TITLE
Removed AVX2 requirement

### DIFF
--- a/src/aesni_helpers.c
+++ b/src/aesni_helpers.c
@@ -59,13 +59,14 @@ void rust_crypto_aesni_setup_working_key_128(
             \
             jmp 2f; \
             \
-            1: \
+	    1: \
             pshufd $0xff, %%xmm2, %%xmm2; \
-            vpslldq $0x04, %%xmm1, %%xmm3; \
+            movdqa %%xmm1, %%xmm3; \
+            pslldq $0x04, %%xmm3; \
             pxor %%xmm3, %%xmm1; \
-            vpslldq $0x4, %%xmm1, %%xmm3; \
+            pslldq $0x04, %%xmm3; \
             pxor %%xmm3, %%xmm1; \
-            vpslldq $0x04, %%xmm1, %%xmm3; \
+            pslldq $0x04, %%xmm3; \
             pxor %%xmm3, %%xmm1; \
             pxor %%xmm2, %%xmm1; \
             movdqu %%xmm1, (%0); \


### PR DESCRIPTION
This branch removed the requirement for the AVX2 instruction set in order to support more processors. https://github.com/librespot-org/librespot currently uses this branch to support processors on certain embedded devices. If this is not detrimental to the main implementation, would like to request that it be merged and published.