### PR TITLE
`gcc::Config` has been renamed to `gcc::Build` [Rust 1.24.1]

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -13,7 +13,7 @@ fn main() {
     let target = env::var("TARGET").unwrap();
     let host = env::var("HOST").unwrap();
     if target.contains("msvc") && host.contains("windows") {
-        let mut config = gcc::Config::new();
+        let mut config = gcc::Build::new();
         config.file("src/util_helpers.asm");
         config.file("src/aesni_helpers.asm");
         if target.contains("x86_64") {
@@ -22,7 +22,7 @@ fn main() {
         config.compile("lib_rust_crypto_helpers.a");
     }
     else {
-        let mut cfg = gcc::Config::new();
+        let mut cfg = gcc::Build::new();
         cfg.file("src/util_helpers.c");
         cfg.file("src/aesni_helpers.c");
         if env::var_os("CC").is_none() {


### PR DESCRIPTION
This fixes the following build warnings when running `cargo build`
against this library:

```
warning: use of deprecated item 'gcc::Config': gcc::Config has been renamed to gcc::Build
  --> build.rs:16:26
   |
16 |         let mut config = gcc::Config::new();
   |                          ^^^^^^^^^^^^^^^^
   |
   = note: #[warn(deprecated)] on by default

warning: use of deprecated item 'gcc::Config': gcc::Config has been renamed to gcc::Build
  --> build.rs:25:23
   |
25 |         let mut cfg = gcc::Config::new();
   |                       ^^^^^^^^^^^^^^^^
```