### PR TITLE
Remove two unused imports from Hmac and Whirlpool tests

### DIFF
--- a/src/hmac.rs
+++ b/src/hmac.rs
@@ -123,7 +123,6 @@ mod test {
 
     use mac::{Mac, MacResult};
     use hmac::Hmac;
-    use digest::Digest;
     use md5::Md5;
 
     struct Test {

--- a/src/whirlpool.rs
+++ b/src/whirlpool.rs
@@ -207,7 +207,6 @@ fn process_buffer(hash: &mut[u64; 8], buffer: &[u8]) {
 mod test {
     use super::*;
     use digest::Digest;
-    use std::ascii::AsciiExt;
 
     static TESTS: [(&'static str, &'static str); 18] = [
         ("", "19FA61D75522A4669B44E39C1D2E1726C530232130D407F89AFEE0964997F7A73E83BE698B288FEBCF88E3E03C4F0757EA8964E59B63D93708B138CC42A66EB3"),


### PR DESCRIPTION
This change removes the following warnings about unused imports:

```
   --> src/hmac.rs:126:9
    |
126 |     use digest::Digest;
    |         ^^^^^^^^^^^^^^
    |
    = note: #[warn(unused_imports)] on by default

warning: unused import: `std::ascii::AsciiExt`
   --> src/whirlpool.rs:210:9
    |
210 |     use std::ascii::AsciiExt;
    |         ^^^^^^^^^^^^^^^^^^^^
```