### PR TITLE
`ref` on an entire `let` pattern is discouraged

### DIFF
--- a/src/sosemanuk.rs
+++ b/src/sosemanuk.rs
@@ -197,8 +197,8 @@ impl Sosemanuk {
         let mut v3 : u32;
         let mut tt : u32;
 
-        let ref mul_alpha = ALPHA_MUL_TABLE;
-        let ref div_alpha = ALPHA_DIV_TABLE;
+        let mul_alpha = &ALPHA_MUL_TABLE;
+        let div_alpha = &ALPHA_DIV_TABLE;
 
         tt = r1;
         //r1 = r2 + (s1 ^ ((r1 & 0x01) != 0 ? s8 : 0));


### PR DESCRIPTION
For let bindings, let x = &foo; is preferred. The type of x is more obvious
with the former.

Small style fix. If you like I can send more :)