### PR TITLE
Fixes issue #445 : I can't compile

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -31,6 +31,8 @@ fn main() {
                 // GCC doesn't like some of the assembly that we use on that
                 // platform.
                 cfg.compiler(Path::new("clang"));
+            } else if target.contains("gnu") {
+                cfg.compiler(Path::new("gcc"));
             } else if target == host {
                 cfg.compiler(Path::new("cc"));
             }


### PR DESCRIPTION
Fixes the build problem which arises when the
* host is windows
* target is x86_64-pc-windows-gnu
The problem is fixed by setting the compiler to gcc.