### PR TITLE
Change fixed_time_eq to avoid undefined behavior

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -41,7 +41,7 @@ pub fn secure_memset(dst: &mut [u8], val: u8) {
 /// Compare two vectors using a fixed number of operations. If the two vectors are not of equal
 /// length, the function returns false immediately.
 pub fn fixed_time_eq(lhs: &[u8], rhs: &[u8]) -> bool {
-    if lhs.len() != rhs.len() {
+    if lhs.len() != rhs.len() || lhs.len() == 0 {
         false
     } else {
         let count = lhs.len() as libc::size_t;
@@ -76,5 +76,6 @@ mod test {
         assert!(!fixed_time_eq(&a, &e));
         assert!(!fixed_time_eq(&a, &f));
         assert!(!fixed_time_eq(&a, &g));
+        assert!(!fixed_time_eq(&[], &[]));
     }
 }


### PR DESCRIPTION
If both slices have `len() == 0`, I think that get_unchecked will have undefined behavior.
I'd say that this is the type of operation that the gain of not checking the boundaries for the first element does not justify the usage of unsafe there, what do you think? 