### PR TITLE
Fix typo ammount -> amount

### DIFF
--- a/src/blockmodes.rs
+++ b/src/blockmodes.rs
@@ -660,14 +660,14 @@ impl <T: BlockDecryptor, X: PaddingProcessor> Decryptor for CbcDecryptor<T, X> {
     }
 }
 
-fn add_ctr(ctr: &mut [u8], mut ammount: u8) {
+fn add_ctr(ctr: &mut [u8], mut amount: u8) {
     for i in ctr.iter_mut().rev() {
         let prev = *i;
-        *i = i.wrapping_add(ammount);
+        *i = i.wrapping_add(amount);
         if *i >= prev {
             break;
         }
-        ammount = 1;
+        amount = 1;
     }
 }
 


### PR DESCRIPTION
Simple fix of a typo discovered while reading the source code.