### PR TITLE
Add deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@
 
 A (mostly) pure-Rust implementation of various common cryptographic algorithms.
 
+---
+
+# Deprecation warning
+
+This project is no longer maintained. You can use: [https://github.com/RustCrypto/](https://github.com/RustCrypto/).
+
+---
+
 Rust-Crypto seeks to create practical, auditable, pure-Rust implementations of common cryptographic
 algorithms with a minimum amount of assembly code where appropriate. The x86-64, x86, and
 ARM architectures are supported, although the x86-64 architecture receives the most testing.


### PR DESCRIPTION
Hi!

So this crate in wonderful and helped a lot some time ago.

Said that, newest commit in this project dates from 5 years ago. Sometimes, when searching things like "scrypt rust" in search engines you get this repository as first result, which is dangerous as it wasn't maintained for 5 year now. See also: https://rustsec.org/advisories/RUSTSEC-2016-0005.html

I think at least this project can show a deprecation warning in the Readme in order to point to https://github.com/RustCrypto/ which is properly maintained.

Hope this PR comes well.
And thanks for all the Job done on this crate.

