### PR TITLE
make secure_memset function unsafe

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -29,13 +29,11 @@ extern {
             count: libc::size_t);
 }
 
-pub fn secure_memset(dst: &mut [u8], val: u8) {
-    unsafe {
-        rust_crypto_util_secure_memset(
-            dst.as_mut_ptr(),
-            val,
-            dst.len() as libc::size_t);
-    }
+pub unsafe fn secure_memset(dst: &mut [u8], val: u8) {
+    rust_crypto_util_secure_memset(
+        dst.as_mut_ptr(),
+        val,
+        dst.len() as libc::size_t);
 }
 
 /// Compare two vectors using a fixed number of operations. If the two vectors are not of equal


### PR DESCRIPTION
https://github.com/DaGenix/rust-crypto/blob/cc1a5fde1ce957bd1a8a2e30169443cdb4780111/src/util.rs#L32-L39
Hello, if a function's entire body is unsafe, the function is itself unsafe and should be marked appropriately, which will make the caller ignore the safety requirements that the function parameters must guarantee, the developer who calls the secure_memset function may not notice this safety requirement.

Marking them unsafe also means that callers must make sure they know what they're doing.